### PR TITLE
enabled channel-wide highlight

### DIFF
--- a/src/Engine-IRC/Protocols/Irc/IrcProtocolManager.cs
+++ b/src/Engine-IRC/Protocols/Irc/IrcProtocolManager.cs
@@ -2485,6 +2485,20 @@ namespace Smuxi.Engine
 
             var msg = builder.ToMessage();
             MarkHighlights(msg);
+			
+			//channel highlight: (if "/#channelname/" is among the highlight words, notify all messages in a specific channel)
+			//it doesn't color the messages, just sets all of them as highlighted (so you are notified)
+			if (ContainsHighlight(e.Data.Channel)) { 
+				//set the message as highlight:
+	            foreach (MessagePartModel msgPart in msg.MessageParts) {
+	                if (!(msgPart is TextMessagePartModel)) {
+	                    continue;
+	                }
+	                TextMessagePartModel textMsg = (TextMessagePartModel) msgPart;
+	                textMsg.IsHighlight = true;
+	            }
+			}	
+			
             Session.AddMessageToChat(chat, msg);
         }
         


### PR DESCRIPTION
Hi,
I added a snippet so that if you have /#channelname/ among the highlight words you will be notified of all messages in that channel (the messages are not colored). 

I needed this personally, cause I watch some very low-activity channels, where people sometimes pop in and I have to promptly respond to them before they disconnect.
Not sure if it's needed by anyone else, and maybe there are better ways to do this. Anyway I'm asking for the pull, feel free whether to pull my code or not.

Also, I didn't add anything documentation-wise, but it probably would be needed for users to know about this functionality. 

Bye
