### PR TITLE
[Frontend-GNOME] Let GTK+ handle all unknown Ctrl-<key>

### DIFF
--- a/src/Frontend-GNOME/Entry.cs
+++ b/src/Frontend-GNOME/Entry.cs
@@ -297,6 +297,10 @@ namespace Smuxi.Frontend.Gnome
                     case Gdk.Key.End:
                         ChatViewManager.CurrentChatView.ScrollToEnd();
                         break;
+                    // anything else we let GTK+ handle
+                    default:
+                        e.RetVal = false;
+                        break;
                 }
             }
             


### PR DESCRIPTION
By not setting the return value to 'false', Smuxi was breaking the
emacs bindings. Let GTK+ handle them so they work.
