### PR TITLE
[Frontend-GNOME] Fall back to the protocol name when looking for the favicon

### DIFF
--- a/src/Frontend-GNOME/Views/Chats/ProtocolChatView.cs
+++ b/src/Frontend-GNOME/Views/Chats/ProtocolChatView.cs
@@ -200,8 +200,9 @@ namespace Smuxi.Frontend.Gnome
 
             string websiteUrl = null;
             lock (NetworkWebsiteUrls) {
-                if (!NetworkWebsiteUrls.TryGetValue(ID, out websiteUrl)) {
-                    // unknown network, nothing to download
+                if (!NetworkWebsiteUrls.TryGetValue(ID, out websiteUrl) &&
+                    !NetworkWebsiteUrls.TryGetValue(protocol, out websiteUrl)) {
+                    // unknown network and protocol, nothing to download
                     return;
                 }
                 // download in background so Sync() doesn't get slowed down


### PR DESCRIPTION
The network ID isn't always a reasonable key, as several networks
could reside on the same server/service and have a common favicon (or
no possiblity of customising it).

If the network ID isn't in the list, fall back to searching for it by
protocol name.
