### PR TITLE
[Engine-IRC] bugfix: Nicklist dropdown menu invite showed other Network'...

### DIFF
--- a/src/Frontend-GNOME-IRC/InviteToMenu.cs
+++ b/src/Frontend-GNOME-IRC/InviteToMenu.cs
@@ -68,6 +68,15 @@ namespace Smuxi.Frontend.Gnome
                 IsPopulated = true;
                 foreach (var chatView in ChatViewManager.Chats) {
                     if (!(chatView is GroupChatView)) {
+                        // only invite to group chats
+                        continue;
+                    }
+                    if (chatView == ChatViewManager.ActiveChat) {
+                        // don't need to add current chat to invite list
+                        continue;
+                    }
+                    if (chatView.ProtocolManager != ProtocolManager) {
+                        // only add chats from current server
                         continue;
                     }
 


### PR DESCRIPTION
...s channels

side effects:
InviteToMenu can now be used by any chat view on any protocol manager
current channel is not shown anymore in InviteToMenu
