### PR TITLE
Campfire: Add topic change support and fix a crash

### DIFF
--- a/src/Engine-Campfire/Protocols/Campfire/CampfireProtocolManager.cs
+++ b/src/Engine-Campfire/Protocols/Campfire/CampfireProtocolManager.cs
@@ -216,6 +216,19 @@ namespace Smuxi.Engine
 
         }
 
+        public void CommandTopic(CommandModel cmd)
+        {
+            Trace.Call(cmd);
+
+            var update = new UpdateTopicWrapper {
+                room = new TopicChange {
+                    topic = cmd.Parameter
+                }
+            };
+
+            Client.Put<object>(String.Format("/room/{0}.json", cmd.Chat.ID), update);
+        }
+
         public void CommandSay(CommandModel cmd)
         {
             Trace.Call(cmd);
@@ -240,6 +253,10 @@ namespace Smuxi.Engine
                     break;
                 case "help":
                     CommandHelp(command);
+                    handled = true;
+                    break;
+                case "topic":
+                    CommandTopic(command);
                     handled = true;
                     break;
                 default: // nothing, normal chat

--- a/src/Engine-Campfire/Protocols/Campfire/DTO.cs
+++ b/src/Engine-Campfire/Protocols/Campfire/DTO.cs
@@ -27,6 +27,8 @@ namespace Smuxi.Engine.Campfire
     internal class MessagesResponse { public Message[] Messages { get; set; } }
     internal class MessageResponse { public Message Message { get; set; } }
     internal class MessageWrapper { public MessageSending message { get; set; } }
+    internal class TopicChange { public string topic { get; set; } }
+    internal class UpdateTopicWrapper { public TopicChange room { get; set; } }
 
     internal enum MessageType {
         EnterMessage,


### PR DESCRIPTION
Support changing the topic via `/topic` and don't crash when typing into the network chat window.
