### PR TITLE
[Engine-XMPP] Fixes null Exception on receipt of presence updates withou...

### DIFF
--- a/src/Engine-XMPP/Protocols/Xmpp/XmppProtocolManager.cs
+++ b/src/Engine-XMPP/Protocols/Xmpp/XmppProtocolManager.cs
@@ -806,7 +806,8 @@ namespace Smuxi.Engine
             builder.AppendEventPrefix();
             PersonModel person = null;
             if (groupChat != null) {
-                person = new PersonModel("", jid.Resource, "", "", this);
+                string displayName = jid.Resource ?? jid.Bare;
+                person = new PersonModel("", displayName, "", "", this);
             } else {
                 person = CreatePerson(jid.Bare);
             }


### PR DESCRIPTION
...t a Resource

there is some bug in the jabber-net lib with muc & presence update (protocol errors getting sent from the server inside the xmpp stream) this "fix" just makes sure it doesn't crash when that happens
