### PR TITLE
[Engine-Campfire] Use a space to separate the user and the action text

### DIFF
--- a/src/Engine-Campfire/Protocols/Campfire/CampfireProtocolManager.cs
+++ b/src/Engine-Campfire/Protocols/Campfire/CampfireProtocolManager.cs
@@ -356,7 +356,7 @@ namespace Smuxi.Engine
         void FormatEvent(MessageBuilder bld, PersonModel person, string action)
         {
             bld.AppendEventPrefix();
-            bld.AppendIdendityName(person);
+            bld.AppendIdendityName(person).AppendSpace();
             bld.AppendText(action);
         }
 


### PR DESCRIPTION
This became missing in a recent refactoring.
