### PR TITLE
[Engine] created MessageBuilder.AppendHtmlMessage()

### DIFF
--- a/src/Engine/Engine.csproj
+++ b/src/Engine/Engine.csproj
@@ -124,6 +124,7 @@
     <Reference Include="Mono.Data.Sqlite" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj">

--- a/src/Engine/Messages/UrlMessagePartModel.cs
+++ b/src/Engine/Messages/UrlMessagePartModel.cs
@@ -79,6 +79,15 @@ namespace Smuxi.Engine
                               this(url, null)
         {
         }
+        
+        public UrlMessagePartModel(TextMessagePartModel model)
+            : base(model)
+        {
+            if (model is UrlMessagePartModel) {
+                _Protocol = (model as UrlMessagePartModel)._Protocol;
+                _Url = (model as UrlMessagePartModel)._Url;
+            }
+        }
 
         public UrlMessagePartModel(string url, string text):
                               this(url, text, UrlProtocol.None)


### PR DESCRIPTION
this function parses a string containing any kind of html (full pages or just snippets) and adds it as smuxi-MessagePartModel to the builder.
Currently supported tags: b, strong, i, em, u, a
All other tags are assumed to have no function except change formatting through a style attribute.
Currently supported styles:
"background-color: #hex;"
"background: #hex;"
"color: #hex;"
"font-style: normal/inherit/italic;"
"font-weight: normal/inherit/bold;"
"text-decoration: underline;"

all other styles are ignored

the <img> tag does not display an image, only a hyperlink to the image.
