### PR TITLE
[Build-Win32] Common.csproj still missing a valid ApplicationIcon.

### DIFF
--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -8,7 +8,8 @@
     <ProjectGuid>{73DEF91D-03FF-41E3-B2E1-3259AF247CA7}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Smuxi.Common</RootNamespace>
-    <ApplicationIcon>.</ApplicationIcon>
+    <ApplicationIcon>
+    </ApplicationIcon>
     <AssemblyName>smuxi-common</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Something must have been wrong, the sln file still needs to be tweaked manually but i think we'll soon able to build smuxi in a proper way directly on Win32.
