### PR TITLE
new tab completion mode: cycle through matches

### DIFF
--- a/glade/smuxi-frontend-gnome.glade
+++ b/glade/smuxi-frontend-gnome.glade
@@ -1751,18 +1751,81 @@ yy/yyyy = year</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <widget class="GtkCheckButton" id="BashStyleCompletionCheckButton">
-                                    <property name="label" translatable="yes">Bash-Style Completion</property>
+                                  <widget class="GtkFrame" id="frame16">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="draw_indicator">True</property>
-                                    <signal name="toggled" handler="_OnChanged"/>
+                                    <property name="label_xalign">0</property>
+                                    <child>
+                                      <widget class="GtkAlignment" id="alignment29">
+                                        <property name="visible">True</property>
+                                        <property name="left_padding">12</property>
+                                        <child>
+                                          <widget class="GtkVBox" id="vbox16">
+                                            <property name="visible">True</property>
+                                            <child>
+                                              <widget class="GtkRadioButton" id="TabCompletionRadioButtonFirstMatch">
+                                                <property name="label" translatable="yes">First Match (irssi)</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="active">True</property>
+                                                <property name="draw_indicator">True</property>
+                                              </widget>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <widget class="GtkRadioButton" id="TabCompletionRadioButtonLongestPrefix">
+                                                <property name="label" translatable="yes">Longest Prefix (bash)</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="active">True</property>
+                                                <property name="draw_indicator">True</property>
+                                                <property name="group">TabCompletionRadioButtonFirstMatch</property>
+                                              </widget>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <widget class="GtkRadioButton" id="TabCompletionRadioButtonTabCycle">
+                                                <property name="label" translatable="yes">Cycle with Tab</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">False</property>
+                                                <property name="active">True</property>
+                                                <property name="draw_indicator">True</property>
+                                                <property name="group">TabCompletionRadioButtonFirstMatch</property>
+                                              </widget>
+                                              <packing>
+                                                <property name="expand">True</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                          </widget>
+                                        </child>
+                                      </widget>
+                                    </child>
+                                    <child>
+                                      <widget class="GtkLabel" id="label66">
+                                        <property name="visible">True</property>
+                                        <property name="label" translatable="yes">&lt;b&gt; Tab Completion &lt;/b&gt;</property>
+                                        <property name="use_markup">True</property>
+                                      </widget>
+                                      <packing>
+                                        <property name="type">label_item</property>
+                                      </packing>
+                                    </child>
                                   </widget>
                                   <packing>
                                     <property name="expand">False</property>
-                                    <property name="fill">False</property>
+                                    <property name="fill">True</property>
                                     <property name="position">1</property>
                                   </packing>
                                 </child>

--- a/src/Engine/Config/Config.cs
+++ b/src/Engine/Config/Config.cs
@@ -280,7 +280,7 @@ namespace Smuxi.Engine
             prefix = "Engine/Users/DEFAULT/Interface/Entry/";
             Get(prefix+"CompletionCharacter", ":");
             Get(prefix+"CommandCharacter", "/");
-            Get(prefix+"BashStyleCompletion", false);
+            Get(prefix+"TabCompletionMode", "FirstMatch");
             Get(prefix+"CommandHistorySize", 30);
 
             prefix = "Engine/Users/DEFAULT/Interface/Notification/";
@@ -494,7 +494,7 @@ namespace Smuxi.Engine
                 LoadUserEntry(user, "Interface/Chat/WrapMode", null);
                 LoadUserEntry(user, "Interface/Entry/CompletionCharacter", null);
                 LoadUserEntry(user, "Interface/Entry/CommandCharacter", null);
-                LoadUserEntry(user, "Interface/Entry/BashStyleCompletion", null);
+                LoadUserEntry(user, "Interface/Entry/TabCompletionMode", null);
                 LoadUserEntry(user, "Interface/Entry/CommandHistorySize", null);
                 LoadUserEntry(user, "Interface/Notification/NotificationAreaIconMode", null);
                 LoadUserEntry(user, "Interface/Notification/MessagingMenuEnabled", null);

--- a/src/Engine/Config/EntrySettings.cs
+++ b/src/Engine/Config/EntrySettings.cs
@@ -26,7 +26,7 @@ namespace Smuxi.Engine
     {
         public string CommandCharacter { get; set; }
         public string CompletionCharacter { get; set; }
-        public bool BashStyleCompletion { get; set; }
+        public TabCompletionMode TabCompletionMode { get; set; }
         public int CommandHistorySize { get; set; }
 
         public EntrySettings()
@@ -34,7 +34,7 @@ namespace Smuxi.Engine
             // internal defaults
             CommandCharacter = "/";
             CompletionCharacter = ":";
-            BashStyleCompletion = false;
+            TabCompletionMode = TabCompletionMode.FirstMatch;
             CommandHistorySize = 30;
         }
 
@@ -48,8 +48,12 @@ namespace Smuxi.Engine
                 config["Interface/Entry/CommandCharacter"];
             CompletionCharacter = (string)
                 config["Interface/Entry/CompletionCharacter"];
-            BashStyleCompletion = (bool)
-                config["Interface/Entry/BashStyleCompletion"];
+            string tabModeStr = (string)
+                config["Interface/Entry/TabCompletionMode"];
+            TabCompletionMode = (TabCompletionMode) Enum.Parse(
+                typeof(TabCompletionMode),
+                tabModeStr
+            );
             CommandHistorySize = (int)
                 config["Interface/Entry/CommandHistorySize"];
         }

--- a/src/Engine/Config/TabCompletionMode.cs
+++ b/src/Engine/Config/TabCompletionMode.cs
@@ -1,0 +1,51 @@
+/*
+ * $Id$
+ * $URL$
+ * $Rev$
+ * $Author$
+ * $Date$
+ *
+ * Smuxi - Smart MUltipleXed Irc
+ *
+ * Copyright (c) 2008 Mirco Bauer <meebey@meebey.net>
+ *
+ * Full GPL License: <http://www.gnu.org/licenses/gpl.txt>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ */
+
+using System;
+
+namespace Smuxi.Engine
+{
+    public enum TabCompletionMode
+    {
+        /// <summary>
+        /// The first match is taken. (irssi style)
+        /// </summary>
+        FirstMatch,
+
+        /// <summary>
+        /// The longest common prefix is completed and a list
+        /// of options is provided. (bash style)
+        /// </summary>
+        LongestPrefix,
+
+        /// <summary>
+        /// Tab cycles through all matches.
+        /// </summary>
+        TabCycle
+    }
+}

--- a/src/Frontend-GNOME/Preferences/PreferencesDialog.cs
+++ b/src/Frontend-GNOME/Preferences/PreferencesDialog.cs
@@ -578,10 +578,19 @@ namespace Smuxi.Frontend.Gnome
                 (string)Frontend.UserConfig["Interface/Entry/CompletionCharacter"];
             ((Gtk.Entry)_Glade["CommandCharacterEntry"]).Text =
                 (string)Frontend.UserConfig["Interface/Entry/CommandCharacter"];
-            ((Gtk.CheckButton)_Glade["BashStyleCompletionCheckButton"]).Active =
-                (bool)Frontend.UserConfig["Interface/Entry/BashStyleCompletion"];
             ((Gtk.SpinButton)_Glade["CommandHistorySizeSpinButton"]).Value =
                 (double)(int)Frontend.UserConfig["Interface/Entry/CommandHistorySize"];
+            string tabStr = (string) Frontend.UserConfig ["Interface/Entry/TabCompletionMode"];
+            TabCompletionMode tabMode = (TabCompletionMode) Enum.Parse(
+                typeof(TabCompletionMode),
+                tabStr
+            );
+            ((Gtk.RadioButton)_Glade["TabCompletionRadioButtonFirstMatch"]).Active =
+                (tabMode == TabCompletionMode.FirstMatch);
+            ((Gtk.RadioButton)_Glade["TabCompletionRadioButtonLongestPrefix"]).Active =
+                (tabMode == TabCompletionMode.LongestPrefix);
+            ((Gtk.RadioButton)_Glade["TabCompletionRadioButtonTabCycle"]).Active =
+                (tabMode == TabCompletionMode.TabCycle);
 
             var highlight_words =
                 (string[]) Frontend.UserConfig["Interface/Chat/HighlightWords"];
@@ -839,10 +848,19 @@ namespace Smuxi.Frontend.Gnome
                 ((Gtk.Entry)_Glade["CompletionCharacterEntry"]).Text;
             Frontend.UserConfig["Interface/Entry/CommandCharacter"]   =
                 ((Gtk.Entry)_Glade["CommandCharacterEntry"]).Text;
-            Frontend.UserConfig["Interface/Entry/BashStyleCompletion"] =
-                ((Gtk.CheckButton)_Glade["BashStyleCompletionCheckButton"]).Active;
             Frontend.UserConfig["Interface/Entry/CommandHistorySize"] =
                 (int)((Gtk.SpinButton)_Glade["CommandHistorySizeSpinButton"]).Value;
+
+            if (((Gtk.RadioButton)_Glade["TabCompletionRadioButtonFirstMatch"]).Active) {
+                Frontend.UserConfig["Interface/Entry/TabCompletionMode"] =
+                    TabCompletionMode.FirstMatch.ToString();
+            } else if (((Gtk.RadioButton)_Glade["TabCompletionRadioButtonLongestPrefix"]).Active) {
+                Frontend.UserConfig["Interface/Entry/TabCompletionMode"] =
+                    TabCompletionMode.LongestPrefix.ToString();
+            } else if (((Gtk.RadioButton)_Glade["TabCompletionRadioButtonTabCycle"]).Active) {
+                Frontend.UserConfig["Interface/Entry/TabCompletionMode"] =
+                    TabCompletionMode.TabCycle.ToString();
+            }
             
             Frontend.UserConfig["Interface/Chat/HighlightWords"] = null;
 


### PR DESCRIPTION
While Smuxi already supports two types of tab completion -- first match (irssi) and longest common prefix (bash) --, I have been missing a third: tab cycle.

On pressing Tab, this mode expands the first match. On pressing Tab again, the previously expanded first match is replaced by the second, and so on. Upon tabbing beyond the last match, it wraps around to the first match again.

This patch introduces such a mode. As my first contribution to Smuxi, I explicitly invite comments.

Also, it seems there is quite some code duplication between the Gnome and the SWF frontend regarding tab completion. Perhaps this should be factored out -- I can do this too, but I'd first like to discuss how.
