### PR TITLE
[Frontend] fix erroneous completion across chats

### DIFF
--- a/src/Frontend-Tests/Mocks/MockChatView.cs
+++ b/src/Frontend-Tests/Mocks/MockChatView.cs
@@ -38,11 +38,7 @@ namespace Smuxi.Frontend
         public void Disable() {}
         public void Sync() {}
         public void Populate() {}
-        public string ID {
-            get {
-                return "MagicalFakeChatView";
-            }
-        }
+        public string ID { get; set; }
         public int Position {
             get {
                 return 0;
@@ -56,6 +52,7 @@ namespace Smuxi.Frontend
 
         public MockChatView()
         {
+            ID = "MagicalFakeChatView";
             Participants = new List<PersonModel>();
             Messages = new List<MessageModel>();
             ProtocolManager = new MockProtocolManager();
@@ -65,6 +62,11 @@ namespace Smuxi.Frontend
         {
             PersonModel pm = new PersonModel(nick, nick, "fakeNetwork", "fakeProto", ProtocolManager);
             Participants.Add(pm);
+        }
+
+        public void ClearParticipants()
+        {
+            Participants.Clear();
         }
 
         public IList<string> ParticipantNicks()

--- a/src/Frontend-Tests/NickCompleterTests.cs
+++ b/src/Frontend-Tests/NickCompleterTests.cs
@@ -418,6 +418,35 @@ namespace Smuxi.Frontend
             Assert.AreEqual("", inputLine);
             Assert.AreEqual(0, curPos);
         }
+
+        [Test]
+        public void TestNoIrssiCompletionAcrossChats() {
+            cv.ID = "#athens";
+            cv.AddParticipant("Hippolyta");
+            cv.AddParticipant("Hermia");
+            cv.AddParticipant("Helena");
+
+            string inputLine = "H";
+            int curPos = 1;
+
+            tcnc.Complete(ref inputLine, ref curPos, cv);
+
+            AssertNoMessagesOutput();
+            Assert.AreEqual("Helena: ", inputLine);
+            Assert.AreEqual(8, curPos);
+
+            // simulate switching chats
+            cv.ClearParticipants();
+            cv.ID = "#elsinore";
+            cv.AddParticipant("Hamlet");
+            cv.AddParticipant("HamletSr|Ghost");
+
+            tcnc.Complete(ref inputLine, ref curPos, cv);
+
+            AssertNoMessagesOutput();
+            Assert.AreEqual("Helena: ", inputLine);
+            Assert.AreEqual(8, curPos);
+        }
     }
 }
 

--- a/src/Frontend/TabCycleNickCompleter.cs
+++ b/src/Frontend/TabCycleNickCompleter.cs
@@ -41,6 +41,7 @@ namespace Smuxi.Frontend
         int PreviousMatchPos { get; set; }
         int PreviousMatchLength { get; set; }
         int PreviousMatchCursorOffset { get; set; } // offset from match pos + match len
+        IChatView PreviousChatView { get; set; }
 
         public TabCycleNickCompleter()
         {
@@ -49,6 +50,7 @@ namespace Smuxi.Frontend
             PreviousMatchPos = -1;
             PreviousMatchLength = -1;
             PreviousMatchCursorOffset = 0;
+            PreviousChatView = null;
         }
 
         public override void Complete(ref string entryLine, ref int cursorPosition, IChatView currentChatView)
@@ -59,7 +61,7 @@ namespace Smuxi.Frontend
             string matchMe = IsolateNickToComplete(entryLine, cursorPosition, out matchPosition, out appendSpace, out leadingAt);
 
             int rematchCursorPosition = PreviousMatchPos + PreviousMatchLength + PreviousMatchCursorOffset;
-            if (PreviousNickIndex != -1 && cursorPosition == rematchCursorPosition) {
+            if (PreviousNickIndex != -1 && currentChatView == PreviousChatView && cursorPosition == rematchCursorPosition) {
                 // re-match
                 PreviousNickIndex = (PreviousNickIndex + 1) % PreviousNicks.Count;
 
@@ -100,6 +102,7 @@ namespace Smuxi.Frontend
                 PreviousNickIndex = 0;
                 PreviousMatchPos = matchPosition;
                 PreviousMatchLength = nick.Length;
+                PreviousChatView = currentChatView;
 
                 // suppress the completion character if we had an @
                 if (leadingAt) {


### PR DESCRIPTION
I found a bug in the tab-completion code I wrote.

When using tab-cycle nick completion mode, successfully triggering completion,
then switching to a different chat, then triggering completion again would
supply a nickname from the previous chat.

Now, if the user switches to a different chat, the completer forgets the
previous nickname list (and refuses to cycle through the completions until a
completion with different input is triggered).

An example of the bug: I am in `#athens` with the participants `Hippolyta`, `Hermia` and `Helena`. I type `H` and press Tab; the nickname is completed to `Helena:`. I switch to another chat, `#elsinore`, with the participants `Hamlet` and `HamletSr|Ghost`. Before the bugfix, pressing Tab again would complete `Hermia:`, although that participant is in `#athens` and I'm looking at `#elsinore`. After the bugfix, no tab completion is performed and `Helena:` remains unchanged.
