### PR TITLE
[Frontend(-Tests)] fix regression in bash style nick completion

### DIFF
--- a/src/Frontend-Tests/NickCompleterTests.cs
+++ b/src/Frontend-Tests/NickCompleterTests.cs
@@ -165,6 +165,22 @@ namespace Smuxi.Frontend
         }
 
         [Test]
+        public void TestInitialPrefixBashCompletionCaseInsensitive()
+        {
+            cv.AddParticipant("Papagena");
+            cv.AddParticipant("papAgeno");
+
+            string inputLine = "Pa";
+            int curPos = 2;
+            lpnc.Complete(ref inputLine, ref curPos, cv);
+
+            Assert.AreEqual(1, cv.MessageCount());
+            Assert.AreEqual("-!- Papagena papAgeno", cv.GetLastMessage().ToString());
+            Assert.AreEqual("Papagen", inputLine);
+            Assert.AreEqual(7, curPos);
+        }
+
+        [Test]
         public void TestInitialPrefixAtBashCompletion()
         {
             cv.AddParticipant("Papagena");

--- a/src/Frontend/LongestPrefixNickCompleter.cs
+++ b/src/Frontend/LongestPrefixNickCompleter.cs
@@ -53,7 +53,7 @@ namespace Smuxi.Frontend
                 if (ret == null) {
                     ret = nick;
                 } else {
-                    while (!nick.StartsWith(ret)) {
+                    while (!nick.StartsWith(ret, StringComparison.OrdinalIgnoreCase)) {
                         // cut off one character at the end
                         ret = ret.Substring(0, ret.Length - 1);
                     }


### PR DESCRIPTION
if capitalization of possible nicknames differed, tab completion erased the already typed characters

NOTE: caps of the autocompleted text is that of the first match
