### PR TITLE
[Engine(|-Test)] Improve URLs-in-brackets detection.

### DIFF
--- a/src/Engine-Tests/MessageParserTests.cs
+++ b/src/Engine-Tests/MessageParserTests.cs
@@ -48,9 +48,9 @@ namespace Smuxi.Engine
         {
             var builder = new MessageBuilder();
             builder.TimeStamp = DateTime.MinValue;
-            builder.AppendText("foo ");
-            builder.AppendUrl("http://example.com", "<http://example.com>");
-            builder.AppendText(" bar");
+            builder.AppendText("foo <");
+            builder.AppendUrl("http://example.com");
+            builder.AppendText("> bar");
             var expectedMsg = builder.ToMessage();
 
             builder = new MessageBuilder();

--- a/src/Engine/Messages/TextMessagePartModel.cs
+++ b/src/Engine/Messages/TextMessagePartModel.cs
@@ -172,6 +172,15 @@ namespace Smuxi.Engine
             f_Text = msgPart.Text;
         }
 
+        public void CopyAttributesFrom(TextMessagePartModel other)
+        {
+            f_ForegroundColor = other.ForegroundColor;
+            f_BackgroundColor = other.BackgroundColor;
+            f_Underline = other.Underline;
+            f_Bold = other.Bold;
+            f_Italic = other.Italic;
+        }
+
         public override string ToString()
         {
             return Text;


### PR DESCRIPTION
URLs may now be prefixed by a specific set of delimiters (the common types1 of brackets and quote marks), which are detected by the regular expression but not considered part of the URL (thanks to match groups). Also, no spurious space is added anymore if a URL is at the end of a line.
