### PR TITLE
[Frontend-GNOME-IRC] Highlight main action in context menu (closes: #869)

### DIFF
--- a/src/Frontend-GNOME-IRC/IrcGroupChatView.cs
+++ b/src/Frontend-GNOME-IRC/IrcGroupChatView.cs
@@ -387,6 +387,12 @@ namespace Smuxi.Frontend.Gnome
 
             base.OnPersonMenuShown(sender, e);
 
+            Gtk.ImageMenuItem query_item = new Gtk.ImageMenuItem(_("Query"));
+            query_item.Activated += OnUserListMenuQueryActivated;
+            PersonMenu.Append(query_item);
+
+            PersonMenu.Append(new Gtk.SeparatorMenuItem());
+
             Gtk.ImageMenuItem op_item = new Gtk.ImageMenuItem(_("Op"));
             op_item.Activated += OnUserListMenuOpActivated;
             PersonMenu.Append(op_item);
@@ -420,10 +426,6 @@ namespace Smuxi.Frontend.Gnome
             PersonMenu.Append(unban_item);
 
             PersonMenu.Append(new Gtk.SeparatorMenuItem());
-
-            Gtk.ImageMenuItem query_item = new Gtk.ImageMenuItem(_("Query"));
-            query_item.Activated += OnUserListMenuQueryActivated;
-            PersonMenu.Append(query_item);
 
             Gtk.ImageMenuItem whois_item = new Gtk.ImageMenuItem(_("Whois"));
             whois_item.Activated += OnUserListMenuWhoisActivated;


### PR DESCRIPTION
Most GUI guidelines recommend that context menus should highlight the
action that is performed when double-clicking the item. This action,
on a nickname, is the Query, and we now place it the first on the menu,
and place a separator after it.
