### PR TITLE
[Engine-XMPP] CS: don't make fields public that the frontend never needs

### DIFF
--- a/src/Engine-XMPP/Protocols/Xmpp/XmppGroupChatModel.cs
+++ b/src/Engine-XMPP/Protocols/Xmpp/XmppGroupChatModel.cs
@@ -24,10 +24,10 @@ namespace Smuxi.Engine
 {
     public class XmppGroupChatModel : GroupChatModel
     {
-        public DateTime LatestSeenStamp { get; set; }
-        public bool SeenNewMessages { get; set; }
-        public string OwnNickname { get; set; }
-        public string Password { get; set; }
+        internal DateTime LatestSeenStamp { get; set; }
+        internal bool SeenNewMessages { get; set; }
+        internal string OwnNickname { get; set; }
+        internal string Password { get; set; }
 
         public XmppGroupChatModel(string id, string name, IProtocolManager networkManager) :
                          base(id, name, networkManager)


### PR DESCRIPTION
oliver@oliver-laptop:~/Projects/smuxi$ git log -p src/Frontend-GNOME-XMPP/ | grep OwnMessage
oliver@oliver-laptop:~/Projects/smuxi$ git log -p src/Frontend-GNOME-XMPP/ | grep SeenNewMessages
oliver@oliver-laptop:~/Projects/smuxi$ git log -p src/Frontend-GNOME-XMPP/ | grep LastSeenStamp
oliver@oliver-laptop:~/Projects/smuxi$ git log -p src/Frontend-GNOME-XMPP/ | grep Password

looks fine to me
