### PR TITLE
campfire: whitelist the streaming hostname

### DIFF
--- a/src/Engine-Campfire/Protocols/Campfire/CampfireProtocolManager.cs
+++ b/src/Engine-Campfire/Protocols/Campfire/CampfireProtocolManager.cs
@@ -132,6 +132,10 @@ namespace Smuxi.Engine
                     if (!whitelist.Contains("campfirenow.com")) {
                         whitelist.Add("campfirenow.com");
                     }
+                    // needed for receiving messages
+                    if (!whitelist.Contains("streaming.campfirenow.com")) {
+                        whitelist.Add("streaming.campfirenow.com");
+                    }
                     if (!whitelist.Contains(Host)) {
                         whitelist.Add(Host);
                     }


### PR DESCRIPTION
We also need to whitelist the streaming.campfirenow.com hostname, or
we won't be able to receive any messages from the server.
