### PR TITLE
[Frontend-GNOME] Added error message for missing log file

### DIFF
--- a/src/Frontend-GNOME/Views/MenuWidget.cs
+++ b/src/Frontend-GNOME/Views/MenuWidget.cs
@@ -337,6 +337,8 @@ namespace Smuxi.Frontend.Gnome
                         SysDiag.Process.Start(
                             ChatViewManager.CurrentChatView.ChatModel.LogFile
                         );
+                    } catch (System.IO.FileNotFoundException) {
+                        Frontend.ShowError(Parent, _("No chat log was found for this chat. Have you turned on logging?"));
                     } catch (Exception ex) {
                         Frontend.ShowError(Parent, ex);
                     }


### PR DESCRIPTION
```
- If the user does not have a log file when clicking on "Open Log",
  alert the user, and suggest the user to enable logging.
```
