### PR TITLE
[Frontend-GNOME] Allow middle-click to close a tab page (closes: #885)

### DIFF
--- a/src/Frontend-GNOME/Views/Chats/ChatView.cs
+++ b/src/Frontend-GNOME/Views/Chats/ChatView.cs
@@ -619,6 +619,8 @@ namespace Smuxi.Frontend.Gnome
             try {
                 if (e.Event.Button == 3) {
                     _TabMenu.Popup(null, null, null, e.Event.Button, e.Event.Time);
+                } else if (e.Event.Button == 2) {
+                    Close ();
                 }
             } catch (Exception ex) {
                 Frontend.ShowException(ex);


### PR DESCRIPTION
Closes https://www.smuxi.org/issues/show/885
