### PR TITLE
[Engine] Fixed NullReferenceException thrown in ChatModel.Close()

### DIFF
--- a/src/Engine/Chats/ChatModel.cs
+++ b/src/Engine/Chats/ChatModel.cs
@@ -206,7 +206,9 @@ namespace Smuxi.Engine
 
         public void Close()
         {
-            MessageBuffer.Dispose();
+            if (MessageBuffer != null) {
+                MessageBuffer.Dispose();
+            }
         }
 
         private string GetLogFile()


### PR DESCRIPTION
This can happen if no messages have ever been added to the ChatModel
