### PR TITLE
[Engine-XMPP] fixed encrypted connections (closes: #890)

### DIFF
--- a/src/Engine-XMPP/Protocols/Xmpp/XmppProtocolManager.cs
+++ b/src/Engine-XMPP/Protocols/Xmpp/XmppProtocolManager.cs
@@ -2295,8 +2295,14 @@ namespace Smuxi.Engine
 
             // XMPP specific settings
             JabberClient.Resource = server.Resource;
-            
-            JabberClient.UseStartTLS = server.UseEncryption;
+
+            if (server.UseEncryption) {
+                JabberClient.UseSSL = true;
+                JabberClient.UseStartTLS = false;
+            } else {
+                JabberClient.UseStartTLS = true;
+                JabberClient.UseSSL = false;
+            }
             if (!server.ValidateServerCertificate) {
                 JabberClient.ClientSocket.OnValidateCertificate += ValidateCertificate;
             }


### PR DESCRIPTION
default is to try StartTls and automatically fallback to plain
if encryption is enabled, legacy SSL is used

NOTE: this will break any currently saved connections, you need to toggle all UseEncryption checkboxes...
