### PR TITLE
[Engine] spaces in commands used to split up text in quotes

### DIFF
--- a/src/Engine-Tests/CommandModelTests.cs
+++ b/src/Engine-Tests/CommandModelTests.cs
@@ -34,6 +34,11 @@ namespace Smuxi.Engine
             Assert.AreEqual("test", cmd.Command);
             Assert.AreEqual("foobar", cmd.Parameter);
 
+            cmd = new CommandModel(null, null, "/", "/test");
+            Assert.IsTrue(cmd.IsCommand);
+            Assert.AreEqual("test", cmd.Command);
+            Assert.AreEqual("", cmd.Parameter);
+
             cmd = new CommandModel(null, null, "/", "/test foo bar");
             Assert.IsTrue(cmd.IsCommand);
             Assert.AreEqual("test", cmd.Command);
@@ -53,6 +58,49 @@ namespace Smuxi.Engine
             Assert.IsTrue(cmd.IsCommand);
             Assert.AreEqual("test", cmd.Command);
             Assert.AreEqual(" foo bar ", cmd.Parameter);
+
+            cmd = new CommandModel(null, null, "/", @"/test ""foo bar""");
+            Assert.IsTrue(cmd.IsCommand);
+            Assert.AreEqual("test", cmd.Command);
+            Assert.AreEqual("\"foo bar\"", cmd.Parameter);
+            Assert.AreEqual("foo bar", cmd.DataArray[1]);
+
+            cmd = new CommandModel(null, null, "/", @"/test ""foo"" bar");
+            Assert.IsTrue(cmd.IsCommand);
+            Assert.AreEqual("test", cmd.Command);
+            Assert.AreEqual("\"foo\" bar", cmd.Parameter);
+            Assert.AreEqual("foo", cmd.DataArray[1]);
+            Assert.AreEqual("bar", cmd.DataArray[2]);
+
+            cmd = new CommandModel(null, null, "/", @"/test """"");
+            Assert.IsTrue(cmd.IsCommand);
+            Assert.AreEqual("test", cmd.Command);
+            Assert.AreEqual("\"\"", cmd.Parameter);
+            Assert.AreEqual("", cmd.DataArray[1]);
+
+            cmd = new CommandModel(null, null, "/", @"//test");
+            Assert.IsFalse(cmd.IsCommand);
+            Assert.AreEqual("", cmd.Parameter);
+            Assert.AreEqual("/test", cmd.DataArray[0]);
+
+            cmd = new CommandModel(null, null, "/", @"/join blub@conf.nowhere.info ""password with spaces"" ""nickname with spaces""");
+            Assert.IsTrue(cmd.IsCommand);
+            Assert.AreEqual("join", cmd.Command);
+            Assert.AreEqual("blub@conf.nowhere.info", cmd.DataArray[1]);
+            Assert.AreEqual("password with spaces", cmd.DataArray[2]);
+            Assert.AreEqual("nickname with spaces", cmd.DataArray[3]);
+
+            cmd = new CommandModel(null, null, "/", @"/test bla""blub");
+            Assert.IsTrue(cmd.IsCommand);
+            Assert.AreEqual("bla\"blub", cmd.Parameter);
+            Assert.AreEqual("/test", cmd.DataArray[0]);
+            Assert.AreEqual("bla\"blub", cmd.DataArray[1]);
+
+            cmd = new CommandModel(null, null, "/", @"/test ""blub""");
+            Assert.IsTrue(cmd.IsCommand);
+            Assert.AreEqual("\"blub\"", cmd.Parameter);
+            Assert.AreEqual("/test", cmd.DataArray[0]);
+            Assert.AreEqual("blub", cmd.DataArray[1]);
         }
     }
 }

--- a/src/Engine/CommandModel.cs
+++ b/src/Engine/CommandModel.cs
@@ -30,6 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Smuxi.Common;
+using System.Text.RegularExpressions;
 
 namespace Smuxi.Engine
 {
@@ -101,18 +102,38 @@ namespace Smuxi.Engine
             Trace.Call(fm, chat == null ? "(null)" : chat.GetType().ToString(), cmdChar, data);
             
             _Data = data;
-            _DataArray = data.Split(new char[] {' '});
-            _Parameter = String.Join(" ", _DataArray, 1, _DataArray.Length - 1);
+            string regex = Regex.Escape(cmdChar);
+            regex += "(?<command>[a-z]+)"; // commands can only contain english keyboard letters
+            string quoted_parameter = @"""(?<parameters>[^""]*)""";
+            string normal_parameter = @"(?<parameters>[^ ]+)";
+            string parameters = @"( +(" + quoted_parameter + "|" + normal_parameter + "))*";
+            regex += parameters + " *"; // may end with spaces
+            regex = "^" + regex + "$"; // parse full string
+            var match = Regex.Match(data, regex, RegexOptions.IgnoreCase);
+
+            if (data.Contains(" ")) {
+                _Parameter = data.Substring(data.IndexOf(' ') + 1);
+            } else {
+                _Parameter = "";
+            }
             _CommandCharacter = cmdChar;
-            if (data.StartsWith(cmdChar) &&
-                !data.StartsWith(cmdChar + cmdChar)) {
+            if (match.Success) {
                 _IsCommand = true;
-                _Command = (_DataArray[0].Length > cmdChar.Length) ?
-                                _DataArray[0].Substring(cmdChar.Length).ToLower() :
-                                String.Empty;
-            } else if (data.StartsWith(cmdChar + cmdChar)) {
-                _Data = data.Substring(cmdChar.Length);
-                _DataArray[0] = _DataArray[0].Substring(cmdChar.Length);
+                _Command = match.Groups["command"].Value;
+                var list = new List<string>();
+                list.Add(cmdChar + _Command);
+                foreach (Capture cap in match.Groups["parameters"].Captures) {
+                    list.Add(cap.Value);
+                }
+                _DataArray = list.ToArray();
+            } else {
+                if (data.StartsWith(cmdChar + cmdChar)) {
+                    _Data = data.Substring(cmdChar.Length);
+                } else if (data.StartsWith(cmdChar)) {
+                    throw new FormatException("command could not be parsed by command regex, regex must be broken");
+                }
+                _DataArray = new string[1];
+                _DataArray[0] = _Data;
             }
             _FrontendManager = fm;
             _Chat = chat;


### PR DESCRIPTION
now something like
/join chatroom "password with spaces"
is technically possible (this is relevant in several places for xmpp)
