### PR TITLE
[Engine] hook env vars SENDER and RECEIVER were excplicitly set in Proto...

### DIFF
--- a/src/Engine/Hooks/Environments/MessageHookEnvironment.cs
+++ b/src/Engine/Hooks/Environments/MessageHookEnvironment.cs
@@ -25,10 +25,16 @@ namespace Smuxi.Engine
     {
         static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0);
 
-        public MessageHookEnvironment(MessageModel msg)
+        public MessageHookEnvironment(MessageModel msg, string sender, string receiver)
         {
             if (msg == null) {
                 throw new ArgumentNullException("msg");
+            }
+            if (sender == null) {
+                throw new ArgumentNullException("sender");
+            }
+            if (receiver == null) {
+                throw new ArgumentNullException("receiver");
             }
 
             var nick = msg.GetNick();
@@ -44,6 +50,9 @@ namespace Smuxi.Engine
             this["MSG_TIMESTAMP_UNIX"] = timestamp.ToString();
             this["MSG_TIMESTAMP_ISO_UTC"] = msg.TimeStamp.ToString("u").Replace('Z', ' ').TrimEnd();
             this["MSG_TIMESTAMP_ISO_LOCAL"] = msg.TimeStamp.ToLocalTime().ToString("u").Replace('Z', ' ').TrimEnd();
+
+            this["SENDER"] = sender;
+            this["RECEIVER"] = receiver;
         }
     }
 }

--- a/src/Engine/Protocols/ProtocolManagerBase.cs
+++ b/src/Engine/Protocols/ProtocolManagerBase.cs
@@ -250,14 +250,13 @@ namespace Smuxi.Engine
 
             var hooks = new HookRunner("protocol-manager", "on-message-sent");
             hooks.Environments.Add(new ChatHookEnvironment(e.Chat));
-            hooks.Environments.Add(new MessageHookEnvironment(e.Message));
-            hooks.Environments.Add(new ProtocolManagerHookEnvironment(this));
-            if (String.IsNullOrEmpty(e.Sender)) {
-                hooks.EnvironmentVariables.Add("SENDER", Me.ID);
-            } else {
-                hooks.EnvironmentVariables.Add("SENDER", e.Sender);
+
+            var sender = e.Sender;
+            if (String.IsNullOrEmpty(sender)) {
+                sender = Me.ID;
             }
-            hooks.EnvironmentVariables.Add("RECEIVER", e.Receiver);
+            hooks.Environments.Add(new MessageHookEnvironment(e.Message, sender, e.Receiver));
+            hooks.Environments.Add(new ProtocolManagerHookEnvironment(this));
 
             var cmdChar = (string) Session.UserConfig["Interface/Entry/CommandCharacter"];
             hooks.Commands.Add(new SessionHookCommand(Session, e.Chat, cmdChar));
@@ -278,14 +277,13 @@ namespace Smuxi.Engine
 
             var hooks = new HookRunner("protocol-manager", "on-message-received");
             hooks.Environments.Add(new ChatHookEnvironment(e.Chat));
-            hooks.Environments.Add(new MessageHookEnvironment(e.Message));
-            hooks.Environments.Add(new ProtocolManagerHookEnvironment(this));
-            hooks.EnvironmentVariables.Add("SENDER", e.Sender);
-            if (String.IsNullOrEmpty(e.Receiver)) {
-                hooks.EnvironmentVariables.Add("RECEIVER", Me.ID);
-            } else {
-                hooks.EnvironmentVariables.Add("RECEIVER", e.Receiver);
+
+            var receiver = e.Receiver;
+            if (String.IsNullOrEmpty(receiver)) {
+                receiver = Me.ID;
             }
+            hooks.Environments.Add(new MessageHookEnvironment(e.Message, e.Sender, receiver));
+            hooks.Environments.Add(new ProtocolManagerHookEnvironment(this));
 
             var cmdChar = (string) Session.UserConfig["Interface/Entry/CommandCharacter"];
             hooks.Commands.Add(new SessionHookCommand(Session, e.Chat, cmdChar));


### PR DESCRIPTION
...colManagerBase while they only exist for MessageHooks
