### PR TITLE
[Engine-XMPP] resource was always "smuxi" which caused collisions when c...

### DIFF
--- a/src/Engine-XMPP/Config/XmppServerModel.cs
+++ b/src/Engine-XMPP/Config/XmppServerModel.cs
@@ -34,7 +34,6 @@ namespace Smuxi.Engine
             // choose somewhat reasonable defaults
             Priorities[PresenceStatus.Online] = 5;
             Priorities[PresenceStatus.Away] = 0;
-            Resource = "smuxi";
             Protocol = "XMPP";
         }
         

--- a/src/Engine-XMPP/Protocols/Xmpp/XmppProtocolManager.cs
+++ b/src/Engine-XMPP/Protocols/Xmpp/XmppProtocolManager.cs
@@ -131,7 +131,6 @@ namespace Smuxi.Engine
             OpenNewChatOnChatState = true;
 
             JabberClient = new XmppClientConnection();
-            JabberClient.Resource = "Smuxi";
             JabberClient.AutoRoster = true;
             JabberClient.AutoPresence = true;
             JabberClient.OnMessage += OnMessage;


### PR DESCRIPTION
...onnecting with multiple smuxi instances

now it's 20 random bytes as hex
