### PR TITLE
Engine(-Tests): recursive html parsing used same TextMessagePartModel in...

### DIFF
--- a/src/Engine-Tests/MessageBuilderTests.cs
+++ b/src/Engine-Tests/MessageBuilderTests.cs
@@ -43,6 +43,42 @@ namespace Smuxi.Engine
         }
 
         [Test]
+        public void AppendHtmlUrlMessage()
+        {
+            var builder = new MessageBuilder();
+            builder.TimeStamp = DateTime.MinValue;
+            string html = @"<a href=""url"">urltext</a>";
+            builder.AppendHtmlMessage(html);
+            var actualMsg = builder.ToMessage();
+
+            builder = new MessageBuilder();
+            builder.TimeStamp = DateTime.MinValue;
+            builder.AppendUrl("url", "urltext");
+
+            var expectedMsg = builder.ToMessage();
+            Assert.AreEqual(expectedMsg, actualMsg);
+        }
+
+        [Test]
+        public void AppendHtmlMessageWithUrls()
+        {
+            var builder = new MessageBuilder();
+            builder.TimeStamp = DateTime.MinValue;
+            string html = @"<p>TextA<a href=""url"">urltext</a>TextB</p>";
+            builder.AppendHtmlMessage(html);
+            var actualMsg = builder.ToMessage();
+
+            builder = new MessageBuilder();
+            builder.TimeStamp = DateTime.MinValue;
+            builder.AppendText("TextA");
+            builder.AppendUrl("url", "urltext");
+            builder.AppendText("TextB");
+
+            var expectedMsg = builder.ToMessage();
+            Assert.AreEqual(expectedMsg, actualMsg);
+        }
+
+        [Test]
         public void AppendHtmlMessageCssFgRed()
         {
             var builder = new MessageBuilder();

--- a/src/Engine/Messages/MessageBuilder.cs
+++ b/src/Engine/Messages/MessageBuilder.cs
@@ -616,7 +616,14 @@ namespace Smuxi.Engine
             }
             if (node.HasChildNodes) {
                 foreach (XmlNode child in node.ChildNodes) {
-                    ParseHtml(child, submodel);
+                    // clone this model
+                    TextMessagePartModel nextmodel;
+                    if (submodel is UrlMessagePartModel) {
+                        nextmodel = new UrlMessagePartModel(submodel);
+                    } else {
+                        nextmodel = new TextMessagePartModel(submodel);
+                    }
+                    ParseHtml(child, nextmodel);
                 }
             } else {
                 // final node


### PR DESCRIPTION
... multiple places

when setting the text of a specific TextMessagePartModel, the text somewhere else in the message also changed
now there are unit tests checking for such behavior
