### PR TITLE
Engine-XMPP: regression from fc69d82cead caused NullRefException when se...

### DIFF
--- a/src/Engine-XMPP/Protocols/Xmpp/XmppProtocolManager.cs
+++ b/src/Engine-XMPP/Protocols/Xmpp/XmppProtocolManager.cs
@@ -1358,17 +1358,21 @@ namespace Smuxi.Engine
             );
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         void SendPrivateMessage(XmppPersonModel person, Jid jid, string text)
         {
             var mesg = new Message(jid, XmppMessageType.chat, text);
-            var res = person.GetOrCreateResource(jid);
-            if (res.NicknameContactKnowsFromMe != Nicknames[0]) {
-                res.NicknameContactKnowsFromMe = Nicknames[0];
-                mesg.Nickname = new Nickname(Nicknames[0]);
+            XmppResourceModel res;
+            if (person.Resources.TryGetValue(jid.Resource ?? "", out res)) {
+                if (res.NicknameContactKnowsFromMe != Nicknames[0]) {
+                    res.NicknameContactKnowsFromMe = Nicknames[0];
+                    mesg.Nickname = new Nickname(Nicknames[0]);
+                }
             }
             JabberClient.Send(mesg);
         }
 
+        [MethodImpl(MethodImplOptions.Synchronized)]
         void SendPrivateMessage(XmppPersonModel person, string text)
         {
             Jid jid = person.Jid;


### PR DESCRIPTION
...nding messages to bare Jids

this was noticed in gtalk, as messages there are always sent to bare Jids.
calling /whois on a contact to which such a message had been sent caused the NullRefException.
this will be properly fixed in refactor/XmppResourceModel
