### PR TITLE
Engine-XMPP: joining a muc, where another resource of the same account i...

### DIFF
--- a/src/Engine-XMPP/Config/XmppPersonModel.cs
+++ b/src/Engine-XMPP/Config/XmppPersonModel.cs
@@ -41,7 +41,6 @@ namespace Smuxi.Engine
         public bool Temporary { get; set; }
         public Jid Jid { get; set; }
         public Dictionary<string, XmppResourceModel> Resources { get; private set; }
-        public Dictionary<Jid, XmppResourceModel> MucResources { get; private set; }
         public SubscriptionType Subscription { get; set; }
         public AskType Ask { get; set; }
         public XmppPersonModel(Jid jid, string nick, XmppProtocolManager protocolManager)
@@ -50,7 +49,6 @@ namespace Smuxi.Engine
             Trace.Call(jid, nick, protocolManager);
             Jid = jid.Bare;
             Resources = new Dictionary<string, XmppResourceModel>();
-            MucResources = new Dictionary<Jid, XmppResourceModel>();
             Ask = AskType.NONE;
             Subscription = SubscriptionType.none;
             Temporary = true;
@@ -87,19 +85,6 @@ namespace Smuxi.Engine
             return ret;
         }
 
-        public XmppResourceModel GetOrCreateMucResource(Jid jid)
-        {
-            Trace.Call(jid);
-            XmppResourceModel ret;
-            if (MucResources.TryGetValue(jid, out ret)) {
-                return ret;
-            }
-            ret = new XmppResourceModel();
-            ret.Name = jid;
-            MucResources.Add(jid, ret);
-            return ret;
-        }
-        
         public List<XmppResourceModel> GetResourcesWithHighestPriority()
         {
             List<XmppResourceModel> ret = new List<XmppResourceModel>();


### PR DESCRIPTION
...s already in, didn't work

i was trying to be smart and reuse the XmppPersonModel for mucs, but it's just not that simple
