### PR TITLE
Engine-XMPP: contacts were able to modify local roster through nickname ...

### DIFF
--- a/src/Engine-XMPP/Protocols/Xmpp/XmppProtocolManager.cs
+++ b/src/Engine-XMPP/Protocols/Xmpp/XmppProtocolManager.cs
@@ -1536,6 +1536,7 @@ namespace Smuxi.Engine
                 var msg = builder.ToMessage();
                 Session.AddMessageToChat(chat, msg);
 
+                chat.Person = contact.ToPersonModel();
                 var msg2 = new MessageModel(msg);
                 msg2.MessageType = MessageType.PersonChatPersonChanged;
                 Session.AddMessageToChat(chat, msg2);


### PR DESCRIPTION
...changes

nicknames are now only processed if there is a non-empty display name for the contact in the roster that differs from the jid

simple enough?
