### PR TITLE
Frontend-GNOME: fix "jump on join Person chat" feature

### DIFF
--- a/src/Frontend-GNOME/ChatViewManager.cs
+++ b/src/Frontend-GNOME/ChatViewManager.cs
@@ -299,7 +299,7 @@ namespace Smuxi.Frontend.Gnome
                 if (Frontend.IsLocalEngine) {
                     if ((chatView is PersonChatView && AutoSwitchPersonChats) ||
                         (chatView is GroupChatView && AutoSwitchGroupChats)) {
-                        CurrentChatNumber = idx;
+                        CurrentChatView = chatView;
                     }
                 }
 


### PR DESCRIPTION
It was jumping to the wrong child on the tree. Tracked down by
me but actually fixed by Mirco.

This fixes issue #151.
