### PR TITLE
README: add both autogen.sh and configure to compiling instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Depending on your operating system and favorite distribution the installation of
 Compiling Source
 ================
 
-    ./configure
+    ./autogen.sh || ./configure
     make
 
 Installing


### PR DESCRIPTION
The advice about running `./configure` only really applies if you got
the sources from a tarball (packager-friendly). Use both `./autogen.sh`
and `./configure` instead, to make it more developer-friendly.
