### PR TITLE
.gitignore: add autotools' `compile`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Makefile
 Makefile.in
 aclocal.m4
 autom4te.cache
+compile
 config.guess
 config.log
 config.status


### PR DESCRIPTION
autoconf now[1] generates a symbolic link named compile (that
targets /usr/share/automake-1.14/compile) in the root of the
repository when running, so let's include it in .gitignore to
achieve a clean `git status` after compiling (or avoid breaking
the build via `git clean -fd`).

[1] This started happening to me since the usage of Ubuntu14.04,
which brings autoconf 2.69, and prints:

configure.ac:16: installing './compile'

(Having AC_PROG_LIBTOOL in that line)
