### PR TITLE
Engine: fix Sqlite buffer paths when having commas in chat IDs

### DIFF
--- a/src/Engine-Twitter/Protocols/Twitter/TwitterProtocolManager.cs
+++ b/src/Engine-Twitter/Protocols/Twitter/TwitterProtocolManager.cs
@@ -2040,7 +2040,7 @@ namespace Smuxi.Engine
             }
 
             PersonModel person;
-            if (!f_Friends.TryGetValue(user.Id.ToString(), out person)) {
+            if (f_Friends == null || !f_Friends.TryGetValue(user.Id.ToString(), out person)) {
                 return CreatePerson(user);
             }
             return person;

--- a/src/Engine/MessageBuffers/SqliteMessageBuffer.cs
+++ b/src/Engine/MessageBuffers/SqliteMessageBuffer.cs
@@ -76,7 +76,8 @@ namespace Smuxi.Engine
         void Init()
         {
             Connection = new SqliteConnection(
-                "Data Source=" + DBPath + ";" +
+                //extra double-quotes are needed to prevent conflicting connectionString chars in the path such as ','
+                "Data Source=\"" + DBPath + "\";" +
                 // enable Write-Ahead-Log (WAL)
                 "Journal Mode=WAL"
             );


### PR DESCRIPTION
Launching a multi-username /timeline command, when using Sqlite
persistence, was giving a ConnectionString initialization error.
The problem was Sqlite handling commas in the same way as semicolons,
so they cannot be used as part of values in the connection string.

The logical way to fix it is replace them with a char that would not
be legal for twitter usernames (so that the timeline for two users
would never collide with the timeline of a user whose username would
be the fomer usernames combined), but that is legal in most filesystems.