### PR TITLE
Engine: bring errors from server.OnConnectCommands to the UI

### DIFF
--- a/src/Engine/Session.cs
+++ b/src/Engine/Session.cs
@@ -1514,13 +1514,25 @@ namespace Smuxi.Engine
                                 if (command.Length == 0) {
                                     continue;
                                 }
-                                CommandModel cd = new CommandModel(
-                                    frontendManager,
-                                    protocolManager.Chat,
-                                    (string) _UserConfig["Interface/Entry/CommandCharacter"],
-                                    command
-                                );
-                                protocolManager.Command(cd);
+
+                                try {
+                                    var cd = new CommandModel(
+                                        frontendManager,
+                                        protocolManager.Chat,
+                                        (string) _UserConfig["Interface/Entry/CommandCharacter"],
+                                        command
+                                    );
+                                    protocolManager.Command(cd);
+                                } catch (Exception ex) {
+#if LOG4NET
+                                    f_Logger.Error("Command in Connected event: Exception", ex);
+#endif
+                                    var msg = CreateMessageBuilder().
+                                        AppendErrorText("Command '{0}' failed. Reason: {1} ({2})",
+                                                        command, ex.Message).
+                                        ToMessage();
+                                    AddMessageToFrontend (frontendManager, protocolManager.Chat, msg);
+                                }
                             }
                         } catch (Exception ex) {
 #if LOG4NET


### PR DESCRIPTION
If the commands to be executed on server connection were to throw
any exception, they were being swallowed and not shown in the UI,
so the user could never notice that there was a problem with them
(for example, having a /timeline command to inspect a Twitter user
that doesn't exist, would not yield any visible problem).