### PR TITLE
Engine: protect calls to events delegate to avoid concurrency issues

### DIFF
--- a/src/Engine/Config/Config.cs
+++ b/src/Engine/Config/Config.cs
@@ -69,8 +69,9 @@ namespace Smuxi.Engine
 
                 // only raise event if the value changed
                 if (!value.Equals(oldValue)) {
-                    if (Changed != null) {
-                        Changed(this, new ConfigChangedEventArgs(key, value));
+                    var handler = Changed;
+                    if (handler != null) {
+                        handler(this, new ConfigChangedEventArgs(key, value));
                     }
                 }
             }
@@ -703,9 +704,9 @@ namespace Smuxi.Engine
                 m_IniDocument.Sections[key].Remove(key);
             }
 #endif
-            
-            if (Changed != null) {
-                Changed(this, new ConfigChangedEventArgs(key, null));
+            var handler = Changed;
+            if (handler != null) {
+                handler(this, new ConfigChangedEventArgs(key, null));
             }
         }
 

--- a/src/Engine/Protocols/ProtocolManagerBase.cs
+++ b/src/Engine/Protocols/ProtocolManagerBase.cs
@@ -216,8 +216,9 @@ namespace Smuxi.Engine
 
             Session.UpdateNetworkStatus();
 
-            if (Connected != null) {
-                Connected(this, e);
+            var handler = Connected;
+            if (handler != null) {
+                handler(this, e);
             }
 
             var hooks = new HookRunner("engine", "protocol-manager", "on-connected");
@@ -245,9 +246,10 @@ namespace Smuxi.Engine
             _PresenceStatus = PresenceStatus.Offline;
 
             Session.UpdateNetworkStatus();
-            
-            if (Disconnected != null) {
-                Disconnected(this, e);
+
+            var handler = Disconnected;
+            if (handler != null) {
+                handler(this, e);
             }
 
             var hooks = new HookRunner("engine", "protocol-manager", "on-disconnected");
@@ -267,8 +269,9 @@ namespace Smuxi.Engine
         {
             Trace.Call(e);
 
-            if (MessageSent != null) {
-                MessageSent(this, e);
+            var handler = MessageSent;
+            if (handler != null) {
+                handler(this, e);
             }
 
             var hooks = new HookRunner("engine", "protocol-manager", "on-message-sent");
@@ -294,8 +297,9 @@ namespace Smuxi.Engine
         {
             Trace.Call(e);
 
-            if (MessageReceived != null) {
-                MessageReceived(this, e);
+            var handler = MessageReceived;
+            if (handler != null) {
+                handler(this, e);
             }
 
             var hooks = new HookRunner("engine", "protocol-manager", "on-message-received");
@@ -321,8 +325,9 @@ namespace Smuxi.Engine
         {
             Trace.Call(e);
 
-            if (PresenceStatusChanged != null) {
-                PresenceStatusChanged(this, e);
+            var handler = PresenceStatusChanged;
+            if (handler != null) {
+                handler(this, e);
             }
 
             var hooks = new HookRunner("engine", "protocol-manager", "on-presence-status-changed");

--- a/src/Engine/Session.cs
+++ b/src/Engine/Session.cs
@@ -1979,8 +1979,9 @@ namespace Smuxi.Engine
 
         protected virtual void OnGroupChatPersonAdded(GroupChatPersonAddedEventArgs e)
         {
-            if (GroupChatPersonAdded != null) {
-                GroupChatPersonAdded(this, e);
+            var handler = GroupChatPersonAdded;
+            if (handler != null) {
+                handler(this, e);
             }
 
             var pm = e.GroupChat.ProtocolManager;
@@ -2029,8 +2030,9 @@ namespace Smuxi.Engine
 
         protected virtual void OnGroupChatPersonUpdated(GroupChatPersonUpdatedEventArgs e)
         {
-            if (GroupChatPersonUpdated != null) {
-                GroupChatPersonUpdated(this, e);
+            var handler = GroupChatPersonUpdated;
+            if (handler != null) {
+                handler(this, e);
             }
 
             var pm = e.GroupChat.ProtocolManager;
@@ -2055,8 +2057,9 @@ namespace Smuxi.Engine
 
         protected virtual void OnEventMessage(EventMessageEventArgs e)
         {
-            if (EventMessage != null) {
-                EventMessage(this, e);
+            var handler = EventMessage;
+            if (handler != null) {
+                handler(this, e);
             }
 
             var pm = e.Chat.ProtocolManager;


### PR DESCRIPTION
This good practice is explained in Gendarme's rule documentation:
http://www.mono-project.com/docs/tools+libraries/tools/gendarme/rules/concurrency/#protectcalltoeventdelegatesrule