### PR TITLE
Moved input box to be only below chat window/user list

### DIFF
--- a/src/Frontend-GNOME/MainWindow.cs
+++ b/src/Frontend-GNOME/MainWindow.cs
@@ -263,9 +263,13 @@ namespace Smuxi.Frontend.Gnome
                 treeviewScrolledWindow.CheckResize();
             };
 
+            var notebookPaned = new Gtk.VPaned();
+            notebookPaned.Pack1(Notebook, true, false);
+            notebookPaned.Pack2(entryScrolledWindow, false, false);
+
             var treeviewPaned = new Gtk.HPaned();
             treeviewPaned.Pack1(treeviewScrolledWindow, false, false);
-            treeviewPaned.Pack2(Notebook, true, false);
+            treeviewPaned.Pack2(notebookPaned, true, false);
             TreeViewHPaned = treeviewPaned;
 
             var entryPaned = new Gtk.VPaned();
@@ -280,7 +284,6 @@ namespace Smuxi.Frontend.Gnome
                 }
             };
             entryPaned.Pack1(treeviewPaned, true, false);
-            entryPaned.Pack2(entryScrolledWindow, false, false);
 
             Gtk.VBox vbox = new Gtk.VBox();
             vbox.PackStart(MenuWidget, false, false, 0);


### PR DESCRIPTION
It's really awkward to have the input box extend all the way to the left below the room/chat tabs. It's more intuitive to have the input right below where your text will display in the chatroom.

This pull request causes the input box to line up with the chat window.