### PR TITLE
Frontend-STFL: Ensure text color contrast (closes #1033).

### DIFF
--- a/src/Frontend-STFL/Frontend.cs
+++ b/src/Frontend-STFL/Frontend.cs
@@ -157,6 +157,9 @@ namespace Smuxi.Frontend.Stfl
             _FrontendConfig = new FrontendConfig(UIName);
             // loading and setting defaults
             _FrontendConfig.Load();
+            if (_FrontendConfig[Frontend.UIName + "/Interface/TerminalBackgroundColor"] == null) {
+                _FrontendConfig[Frontend.UIName + "/Interface/TerminalBackgroundColor"] = "#000000";
+            }
             _FrontendConfig.Save();
 
             if (_FrontendConfig.IsCleanConfig) {

--- a/src/Frontend-STFL/Views/ChatView.cs
+++ b/src/Frontend-STFL/Views/ChatView.cs
@@ -271,8 +271,16 @@ namespace Smuxi.Frontend.Stfl
                     var tags = new List<string>();
                     if (txtPart.ForegroundColor != TextColor.None) {
                         var palette = TextColorPalettes.LinuxConsole;
+                        var foregroundColor = txtPart.ForegroundColor;
+                        var backgroundColorString = (string)Frontend.FrontendConfig[Frontend.UIName + "/Interface/TerminalBackgroundColor"];
+                        if (!String.IsNullOrEmpty(backgroundColorString)) {
+                            foregroundColor = TextColorTools.GetBestTextColor(
+                                foregroundColor,
+                                TextColor.Parse(backgroundColorString)
+                            );
+                        }
                         var color = TextColorTools.GetNearestColor(
-                            txtPart.ForegroundColor,
+                            foregroundColor,
                             palette
                         );
                         var colorNumber = palette.IndexOf(color);


### PR DESCRIPTION
Make the terminal background color configurable as STFL/Interface/TerminalBackgroundColor and use GetBestTextColor to ensure sufficient contrast.

Implemented when "black on black" turned out not to be very legible.