### PR TITLE
Frontend-STFL: Handle image message parts (closes #1035).

### DIFF
--- a/src/Frontend-STFL/Views/ChatView.cs
+++ b/src/Frontend-STFL/Views/ChatView.cs
@@ -314,6 +314,11 @@ namespace Smuxi.Frontend.Stfl
                         line.Append(escapedText);
                     }
                     msgLength += txtPart.Text.Length;
+                } else if (msgPart is ImageMessagePartModel) {
+                    var imgPart = (ImageMessagePartModel)msgPart;
+                    string escapedAltText = StflApi.EscapeRichText(imgPart.AlternativeText);
+                    line.Append(escapedAltText);
+                    msgLength += escapedAltText.Length;
                 }
             }
 


### PR DESCRIPTION
Whenever an ImageMessagePartModel is encountered, output the AlternativeText.