### PR TITLE
build: set libray path for 'run' target on OS X.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -313,6 +313,9 @@ dist-linux-debs:
 
 run: run-gnome
 run-gnome: all
+	if [ "x$(shell uname)" = "xDarwin" ]; then \
+	  export DYLD_FALLBACK_LIBRARY_PATH=/Library/Frameworks/Mono.framework/Versions/Current/lib:/lib:/usr/lib; \
+	fi; \
 	cd $(BUILD_DIR) && \
 		mono --debug ./smuxi-frontend-gnome.exe -d
 


### PR DESCRIPTION
When we're on OS X, some of the libraries we need aren't readily
available from the system. We must therefore set up a fallback path for
the linker to look in mono's library dir, where e.g. libintl lives.

We do this in the script for Smuxi.app already, so let's use the same
paths in the Makefile.