### PR TITLE
Engine: fix typo in catch block

### DIFF
--- a/src/Engine/Session.cs
+++ b/src/Engine/Session.cs
@@ -1529,7 +1529,7 @@ namespace Smuxi.Engine
 #endif
                                     var msg = CreateMessageBuilder().
                                         AppendErrorText("Command '{0}' failed. Reason: {1} ({2})",
-                                                        command, ex.Message).
+                                                        command, ex.Message, ex.GetType()).
                                         ToMessage();
                                     AddMessageToFrontend (frontendManager, protocolManager.Chat, msg);
                                 }


### PR DESCRIPTION
This typo was introduced in this commit:
https://github.com/meebey/smuxi/commit/aba9e8f9395c4c6fd879d65d99f373ee0de81ea5

And it was generating an uncaught FormatException due to not
providing the {2}-indexed element.