### PR TITLE
Engine: allow Message to have URLs (so that tweets can have links)

### DIFF
--- a/src/Engine-Twitter/Protocols/Twitter/TwitterMessageBuilder.cs
+++ b/src/Engine-Twitter/Protocols/Twitter/TwitterMessageBuilder.cs
@@ -40,6 +40,9 @@ namespace Smuxi.Engine
 
             // MessageModel serializer expects UTC values
             TimeStamp = status.CreatedDate.ToUniversalTime();
+
+            ID = status.StringId;
+
             AppendSenderPrefix(sender, isHighlight);
 
             // LAME: Twitter lies in the truncated field and says it's not

--- a/src/Engine/Messages/MessageBuilder.cs
+++ b/src/Engine/Messages/MessageBuilder.cs
@@ -59,6 +59,15 @@ namespace Smuxi.Engine
             }
         }
 
+        public string ID {
+            get {
+                return Message.ID;
+            }
+            set {
+                Message.ID = value;
+            }
+        }
+
         public bool IsEmpty {
             get {
                 return Message.IsEmpty;

--- a/src/Engine/Messages/MessageModel.cs
+++ b/src/Engine/Messages/MessageModel.cs
@@ -52,6 +52,12 @@ namespace Smuxi.Engine
         }
 
         [DataMember]
+        public string ID {
+            get;
+            set;
+        }
+
+        [DataMember]
         public IList<MessagePartModel> MessageParts {
             get {
                 return f_MessageParts;

--- a/src/Frontend-GNOME-Twitter/Frontend-GNOME-Twitter.csproj
+++ b/src/Frontend-GNOME-Twitter/Frontend-GNOME-Twitter.csproj
@@ -50,6 +50,8 @@
   <ItemGroup>
     <Compile Include="TwitterGroupChatView.cs" />
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="TwitterMessageTextView.cs" />
+    <Compile Include="TwitterPersonChatView.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Frontend-GNOME-Twitter/Makefile.am
+++ b/src/Frontend-GNOME-Twitter/Makefile.am
@@ -6,7 +6,9 @@ ASSEMBLY_TARGET = $(TARGET_DIR)/$(ASSEMBLY_FILENAME)
 SOURCES = \
 	$(top_srcdir)/src/AssemblyVersion.cs \
 	AssemblyInfo.cs \
-	TwitterGroupChatView.cs
+	TwitterGroupChatView.cs \
+	TwitterMessageTextView.cs \
+	TwitterPersonChatView.cs
 
 REFERENCES = \
 	System \

--- a/src/Frontend-GNOME-Twitter/TwitterGroupChatView.cs
+++ b/src/Frontend-GNOME-Twitter/TwitterGroupChatView.cs
@@ -37,6 +37,11 @@ namespace Smuxi.Frontend.Gnome
             Trace.Call(groupChat);
         }
 
+        protected override MessageTextView CreateMainMessageTextView()
+        {
+            return new TwitterMessageTextView();
+        }
+
         protected override void OnPersonMenuShown(object sender, EventArgs e)
         {
             Trace.Call(sender, e);

--- a/src/Frontend-GNOME-Twitter/TwitterMessageTextView.cs
+++ b/src/Frontend-GNOME-Twitter/TwitterMessageTextView.cs
@@ -1,0 +1,55 @@
+﻿// Smuxi - Smart MUltipleXed Irc
+//
+// Copyright (c) 2015 Andrés G. Aragoneses <knocte@gmail.com>
+//
+// Full GPL License: <http://www.gnu.org/licenses/gpl.txt>
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+
+using System;
+using System.Collections.Generic;
+
+using Smuxi.Engine;
+
+namespace Smuxi.Frontend.Gnome
+{
+    public class TwitterMessageTextView : MessageTextView
+    {
+        protected override void InsertTimeStamp(Gtk.TextBuffer buffer, ref Gtk.TextIter iter,
+                                                string timestamp, MessageModel msg)
+        {
+            if (String.IsNullOrWhiteSpace(msg.ID)) {
+                buffer.Insert(ref iter, timestamp);
+            } else {
+                var uri = new Uri(String.Format("https://twitter.com/{0}/status/{1}", msg.GetNick(), msg.ID));
+
+                var tags = new List<Gtk.TextTag>();
+                // link URI tag
+                var linkTag = new LinkTag(uri);
+                linkTag.TextEvent += OnLinkTagTextEvent;
+                _MessageTextTagTable.Add(linkTag);
+                tags.Add(linkTag);
+
+                // link style tag
+                tags.Add(LinkTag);
+
+                buffer.InsertWithTags(ref iter, timestamp, tags.ToArray());
+            }
+
+            buffer.Insert(ref iter, " ");
+        }
+    }
+}
+

--- a/src/Frontend-GNOME-Twitter/TwitterPersonChatView.cs
+++ b/src/Frontend-GNOME-Twitter/TwitterPersonChatView.cs
@@ -1,0 +1,41 @@
+﻿/*
+ * Smuxi - Smart MUltipleXed Irc
+ *
+ * Copyright (c) 2015 Andrés G. Aragoneses <knocte@gmail.com>
+ *
+ * Full GPL License: <http://www.gnu.org/licenses/gpl.txt>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ */
+
+using Smuxi.Engine;
+using Smuxi.Common;
+
+namespace Smuxi.Frontend.Gnome
+{
+    [ChatViewInfo(ChatType = ChatType.Person, ProtocolManagerType = typeof(TwitterProtocolManager))]
+    public class TwitterPersonChatView : PersonChatView
+    {
+        public TwitterPersonChatView(PersonChatModel personChat) : base(personChat)
+        {
+            Trace.Call(personChat);
+        }
+
+        protected override MessageTextView CreateMainMessageTextView()
+        {
+            return new TwitterMessageTextView();
+        }
+    }
+}

--- a/src/Frontend-GNOME/Views/Chats/ChatView.cs
+++ b/src/Frontend-GNOME/Views/Chats/ChatView.cs
@@ -290,6 +290,11 @@ namespace Smuxi.Frontend.Gnome
             get;
         }
 
+        protected virtual MessageTextView CreateMainMessageTextView()
+        {
+            return new MessageTextView();
+        }
+
         public event EventHandler<ChatViewMessageHighlightedEventArgs> MessageHighlighted;
 
         public ChatView(ChatModel chat)
@@ -299,7 +304,7 @@ namespace Smuxi.Frontend.Gnome
             _ChatModel = chat;
 
             IsAutoScrolling = true;
-            MessageTextView tv = new MessageTextView();
+            MessageTextView tv = CreateMainMessageTextView();
             _EndMark = tv.Buffer.CreateMark("end", tv.Buffer.EndIter, false); 
             tv.ShowTimestamps = true;
             tv.ShowMarkerline = true;

--- a/src/Frontend-GNOME/Views/MessageTextView.cs
+++ b/src/Frontend-GNOME/Views/MessageTextView.cs
@@ -41,7 +41,7 @@ namespace Smuxi.Frontend.Gnome
         private static readonly Gdk.Cursor _LinkCursor = new Gdk.Cursor(Gdk.CursorType.Hand2);
         static readonly Regex NickRegex = new Regex("^(<([^ ]+)> )");
         static bool IsGtk2_17 { get; set; }
-        private Gtk.TextTagTable _MessageTextTagTable;
+        protected Gtk.TextTagTable _MessageTextTagTable;
         private MessageModel _LastMessage;
         private bool         _ShowTimestamps;
         private bool         _ShowHighlight;
@@ -57,7 +57,7 @@ namespace Smuxi.Frontend.Gnome
         Gtk.TextTag BoldTag { get; set; }
         Gtk.TextTag ItalicTag { get; set; }
         Gtk.TextTag UnderlineTag { get; set; }
-        Gtk.TextTag LinkTag { get; set; }
+        protected Gtk.TextTag LinkTag { get; set; }
         Gtk.TextTag EventTag { get; set; }
 
         Gtk.TextTag PersonTag { get; set; }
@@ -374,6 +374,13 @@ namespace Smuxi.Frontend.Gnome
             AddMessage(msg, addLinebreak, _ShowTimestamps);
         }
 
+        protected virtual void InsertTimeStamp(Gtk.TextBuffer buffer, ref Gtk.TextIter iter,
+                                               string timestamp, MessageModel msg)
+        {
+            timestamp = String.Format("{0} ", timestamp);
+            buffer.Insert(ref iter, timestamp);
+        }
+
         public void AddMessage(MessageModel msg, bool addLinebreak, bool showTimestamps)
         {
 #if MSG_DEBUG
@@ -433,8 +440,7 @@ namespace Smuxi.Frontend.Gnome
                 }
 
                 if (timestamp != null) {
-                    timestamp = String.Format("{0} ", timestamp);
-                    buffer.Insert(ref iter, timestamp);
+                    InsertTimeStamp(buffer, ref iter, timestamp, msg);
 
                     // apply timestamp width to indent tag
                     if (indentTag != null) {


### PR DESCRIPTION
In some engines such as Twitter, each message can contain a publicly
accessible URL associated to it. So we add the possibility to include
this URL in MessageModel as a property, so that Frontend-GNOME can use
it as a link from its timestamp (inspired in how the Twitter web UI
works: if you click on the date of the message, you go to the URL of
the single tweet).