### PR TITLE
Frontend: fix nick re-completion if line modified but same length as before

### DIFF
--- a/src/Frontend-Tests/NickCompleterTests.cs
+++ b/src/Frontend-Tests/NickCompleterTests.cs
@@ -452,16 +452,42 @@ namespace Smuxi.Frontend
             Assert.AreEqual(8, curPos);
 
             // simulate switching chats
-            cv.ClearParticipants();
-            cv.ID = "#elsinore";
-            cv.AddParticipant("Hamlet");
-            cv.AddParticipant("HamletSr|Ghost");
+            var elsinoreCV = new MockChatView();
+            elsinoreCV.ID = "#elsinore";
+            elsinoreCV.AddParticipant("Hamlet");
+            elsinoreCV.AddParticipant("HamletSr|Ghost");
 
-            tcnc.Complete(ref inputLine, ref curPos, cv);
+            tcnc.Complete(ref inputLine, ref curPos, elsinoreCV);
 
             AssertNoMessagesOutput();
             Assert.AreEqual("Helena: ", inputLine);
             Assert.AreEqual(8, curPos);
+        }
+
+        [Test]
+        public void TestNoRecompletionIfLineChangesButSameLength() {
+            cv.ID = "#athena";
+            cv.AddParticipant("Hippolyta");
+            cv.AddParticipant("Hermia");
+            cv.AddParticipant("Helena");
+
+            string inputLine = "Hip";
+            int curPos = 3;
+
+            tcnc.Complete(ref inputLine, ref curPos, cv);
+
+            AssertNoMessagesOutput();
+            Assert.AreEqual("Hippolyta: ", inputLine);
+            Assert.AreEqual(11, curPos);
+
+            // replace with a message of the same length
+            inputLine = "/kick Hermi";
+
+            tcnc.Complete(ref inputLine, ref curPos, cv);
+
+            AssertNoMessagesOutput();
+            Assert.AreEqual("/kick Hermia ", inputLine);
+            Assert.AreEqual(13, curPos);
         }
     }
 }

--- a/src/Frontend/TabCycleNickCompleter.cs
+++ b/src/Frontend/TabCycleNickCompleter.cs
@@ -42,6 +42,7 @@ namespace Smuxi.Frontend
         int PreviousMatchLength { get; set; }
         int PreviousMatchCursorOffset { get; set; } // offset from match pos + match len
         IChatView PreviousChatView { get; set; }
+        string InitialMatch { get; set; }
 
         public TabCycleNickCompleter()
         {
@@ -51,6 +52,7 @@ namespace Smuxi.Frontend
             PreviousMatchLength = -1;
             PreviousMatchCursorOffset = 0;
             PreviousChatView = null;
+            InitialMatch = null;
         }
 
         public override void Complete(ref string entryLine, ref int cursorPosition, IChatView currentChatView)
@@ -61,7 +63,8 @@ namespace Smuxi.Frontend
             string matchMe = IsolateNickToComplete(entryLine, cursorPosition, out matchPosition, out appendSpace, out leadingAt);
 
             int rematchCursorPosition = PreviousMatchPos + PreviousMatchLength + PreviousMatchCursorOffset;
-            if (PreviousNickIndex != -1 && currentChatView == PreviousChatView && cursorPosition == rematchCursorPosition) {
+            if (PreviousNickIndex != -1 && currentChatView == PreviousChatView && cursorPosition == rematchCursorPosition
+                && InitialMatch != null && (matchMe.Length == 0 || matchMe.StartsWith(InitialMatch))) {
                 // re-match
                 PreviousNickIndex = (PreviousNickIndex + 1) % PreviousNicks.Count;
 
@@ -75,6 +78,9 @@ namespace Smuxi.Frontend
 
                 return;
             }
+
+            // store this to check for re-matches
+            InitialMatch = matchMe;
 
             // don't re-match even if the user moves the cursor back to the "correct" position
             PreviousNickIndex = -1;


### PR DESCRIPTION
If a nickname is tab-cycle-completed and the line is then replaced with a line of equal length, triggering completion again would cause re-completion instead of fresh completion. Fix this and supply a unit test.