### PR TITLE
UTF-32-related fixes to Frontend-STFL

### DIFF
--- a/src/Frontend-STFL/Frontend-STFL.csproj
+++ b/src/Frontend-STFL/Frontend-STFL.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Views\ChatView.cs" />
     <Compile Include="Views\GroupChatView.cs" />
     <Compile Include="Views\PersonChatView.cs" />
+    <Compile Include="STFL\StringOnHeap.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="MainWindow.stfl">

--- a/src/Frontend-STFL/Makefile.am
+++ b/src/Frontend-STFL/Makefile.am
@@ -55,6 +55,7 @@ FILES = \
 	STFL/KeyPressedEventArgs.cs \
 	STFL/NcursesApi.cs \
 	STFL/StflApi.cs \
+	STFL/StringOnHeap.cs \
 	STFL/TextView.cs \
 	STFL/Widget.cs \
 	Views/ChatView.cs \

--- a/src/Frontend-STFL/STFL/StflApi.cs
+++ b/src/Frontend-STFL/STFL/StflApi.cs
@@ -96,7 +96,7 @@ namespace Stfl
             if (res == IntPtr.Zero) {
                 return null;
             }
-            return UnixMarshal.PtrToString(res, Encoding.UTF32);
+            return FromUnixWideCharacters(res);
         }
 
         [DllImport("stfl")]
@@ -127,7 +127,7 @@ namespace Stfl
             if (res == IntPtr.Zero) {
                 return null;
             }
-            return UnixMarshal.PtrToString(res, Encoding.UTF32);
+            return FromUnixWideCharacters(res);
         }
         
         [DllImport("stfl")]

--- a/src/Frontend-STFL/STFL/StflApi.cs
+++ b/src/Frontend-STFL/STFL/StflApi.cs
@@ -115,12 +115,9 @@ namespace Stfl
             return Utf32NativeEndian.GetString(utf32Bytes);
         }
 
-        public static IntPtr ToUnixWideCharacters(string text)
+        public static StringOnHeap ToUnixWideCharacters(string text)
         {
-            if (text == null) {
-                return IntPtr.Zero;
-            }
-            return UnixMarshal.StringToHeap(text, Utf32NativeEndian);
+            return new StringOnHeap(text, Utf32NativeEndian);
         }
 
         public static string FromUnixWideCharacters(IntPtr text)
@@ -146,7 +143,9 @@ namespace Stfl
         static extern IntPtr stfl_create(IntPtr text);
         internal static IntPtr stfl_create(string text)
         {
-            return stfl_create(ToUnixWideCharacters(text));
+            using (var heapText = ToUnixWideCharacters(text)) {
+                return stfl_create(heapText.Pointer);
+            }
         }
 
         [DllImport("stfl")]
@@ -170,17 +169,21 @@ namespace Stfl
         static extern IntPtr stfl_get(IntPtr form, IntPtr name);
         internal static string stfl_get(IntPtr form, string text)
         {
-            return FromUnixWideCharacters(
-                stfl_get(form, ToUnixWideCharacters(text))
-            );
+            using (var heapText = ToUnixWideCharacters(text)) {
+                return FromUnixWideCharacters(
+                    stfl_get(form, heapText.Pointer)
+                );
+            }
         }
 
         [DllImport("stfl")]
         static extern void stfl_set(IntPtr form, IntPtr name, IntPtr value);
         internal static void stfl_set(IntPtr form, string name, string value)
         {
-            stfl_set(form, ToUnixWideCharacters(name),
-                     ToUnixWideCharacters(value));
+            using (var heapName = ToUnixWideCharacters(name))
+            using (var heapValue = ToUnixWideCharacters(value)) {
+                stfl_set(form, heapName.Pointer, heapValue.Pointer);
+            }
         }
         
         [DllImport("stfl", EntryPoint = "stfl_get_focus")]
@@ -188,9 +191,6 @@ namespace Stfl
         internal static string stfl_get_focus(IntPtr form)
         {
             IntPtr res = stfl_get_focus_native(form);
-            if (res == IntPtr.Zero) {
-                return null;
-            }
             return FromUnixWideCharacters(res);
         }
         
@@ -198,15 +198,20 @@ namespace Stfl
         static extern void stfl_set_focus(IntPtr form, IntPtr name);
         internal static void stfl_set_focus(IntPtr form, string name)
         {
-            stfl_set_focus(form, ToUnixWideCharacters(name));
+            using (var heapName = ToUnixWideCharacters(name)) {
+                stfl_set_focus(form, heapName.Pointer);
+            }
         }
 
         [DllImport("stfl")]
         static extern IntPtr stfl_quote(IntPtr text);
-        internal static string stfl_quote(string text) {
-            return FromUnixWideCharacters(
-                stfl_quote(ToUnixWideCharacters(text))
-            );
+        internal static string stfl_quote(string text)
+        {
+            using (var heapText = ToUnixWideCharacters(text)) {
+                return FromUnixWideCharacters(
+                    stfl_quote(heapText.Pointer)
+                );
+            }
         }
 
         [DllImport("stfl")]
@@ -215,10 +220,12 @@ namespace Stfl
         internal static string stfl_dump(IntPtr form, string name,
                                          string prefix, int focus)
         {
-            return FromUnixWideCharacters(
-                    stfl_dump(form, ToUnixWideCharacters(name),
-                              ToUnixWideCharacters(prefix), focus)
-            );
+            using (var heapName = ToUnixWideCharacters(name))
+            using (var heapPrefix = ToUnixWideCharacters(prefix)) {
+                return FromUnixWideCharacters(
+                    stfl_dump(form, heapName.Pointer, heapPrefix.Pointer, focus)
+                );
+            }
         }
 
         [DllImport("stfl")]
@@ -227,9 +234,12 @@ namespace Stfl
         internal static void stfl_modify(IntPtr form, string name, string mode,
                                          string text)
         {
-            stfl_modify(form, ToUnixWideCharacters(name),
-                        ToUnixWideCharacters(mode),
-                        ToUnixWideCharacters(text));
+            using (var heapName = ToUnixWideCharacters(name))
+            using (var heapMode = ToUnixWideCharacters(mode))
+            using (var heapText = ToUnixWideCharacters(text)) {
+                stfl_modify(form, heapName.Pointer, heapMode.Pointer,
+                    heapText.Pointer);
+            }
         }
 
         [DllImport("stfl")]
@@ -238,10 +248,12 @@ namespace Stfl
         internal static string stfl_lookup(IntPtr form, string path,
                                            string newname)
         {
-            return FromUnixWideCharacters(
-                stfl_lookup(form, ToUnixWideCharacters(path),
-                            ToUnixWideCharacters(newname))
-            );
+            using (var heapPath = ToUnixWideCharacters(path))
+            using (var heapNewName = ToUnixWideCharacters(newname)) {
+                return FromUnixWideCharacters(
+                    stfl_lookup(form, heapPath.Pointer, heapNewName.Pointer)
+                );
+            }
         }
 
         [DllImport("stfl", EntryPoint = "stfl_error")]
@@ -255,7 +267,9 @@ namespace Stfl
         static extern void stfl_error_action(IntPtr mode);
         internal static void stfl_error_action(string mode)
         {
-            stfl_error_action(ToUnixWideCharacters(mode));
+            using (var heapMode = ToUnixWideCharacters(mode)) {
+                stfl_error_action(heapMode.Pointer);
+            }
         }
 
         /*

--- a/src/Frontend-STFL/STFL/StflApi.cs
+++ b/src/Frontend-STFL/STFL/StflApi.cs
@@ -34,6 +34,7 @@ namespace Stfl
         static bool IsUtf8Locale { get; set; }
         static string EscapeLessThanCharacter  { get; set; }
         static string EscapeGreaterThanCharacter { get; set; }
+        static Encoding Utf32NativeEndian { get; set; }
 
         static StflApi()
         {
@@ -53,6 +54,12 @@ namespace Stfl
 
             EscapeLessThanCharacter = "<>";
             EscapeGreaterThanCharacter = ">";
+
+            Utf32NativeEndian = new UTF32Encoding(
+                bigEndian: !BitConverter.IsLittleEndian,
+                byteOrderMark: false,
+                throwOnInvalidCharacters: true
+            );
         }
 
         public static IntPtr ToUnixWideCharacters(string text)
@@ -60,7 +67,7 @@ namespace Stfl
             if (text == null) {
                 return IntPtr.Zero;
             }
-            return UnixMarshal.StringToHeap(text, Encoding.UTF32);
+            return UnixMarshal.StringToHeap(text, Utf32NativeEndian);
         }
 
         public static string FromUnixWideCharacters(IntPtr text)
@@ -68,7 +75,7 @@ namespace Stfl
             if (text == IntPtr.Zero) {
                 return null;
             }
-            return UnixMarshal.PtrToString(text, Encoding.UTF32);
+            return UnixMarshal.PtrToString(text, Utf32NativeEndian);
         }
 
         public static string EscapeRichText(string text)

--- a/src/Frontend-STFL/STFL/StringOnHeap.cs
+++ b/src/Frontend-STFL/STFL/StringOnHeap.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * Smuxi - Smart MUltipleXed Irc
+ *
+ * Copyright (c) 2010-2015 Mirco Bauer <meebey@meebey.net>
+ * Copyright (c) 2015 Ondrej Hosek <ondra.hosek@gmail.com>
+ *
+ * Full GPL License: <http://www.gnu.org/licenses/gpl.txt>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+ */
+using System;
+using System.Text;
+using Mono.Unix;
+
+namespace Stfl
+{
+    public sealed class StringOnHeap : IDisposable
+    {
+        public IntPtr Pointer { get; private set; }
+
+        public StringOnHeap(string str, Encoding encoding)
+        {
+            if (str == null) {
+                Pointer = IntPtr.Zero;
+                return;
+            }
+            Pointer = UnixMarshal.StringToHeap(str, encoding);
+        }
+
+        public void Dispose()
+        {
+            if (Pointer != IntPtr.Zero) {
+                UnixMarshal.FreeHeap(Pointer);
+                Pointer = IntPtr.Zero;
+            }
+            GC.SuppressFinalize(this);
+        }
+
+        ~StringOnHeap()
+        {
+            if (Pointer != IntPtr.Zero) {
+                UnixMarshal.FreeHeap(Pointer);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Remove code duplication, fix serialization for big-endian systems, work around Mono.Unix.UnixMarshal.PtrToString breakage with UTF-32, fix memory leaks.