### PR TITLE
Frontend-STFL: Fix the UTF-32 workaround.

### DIFF
--- a/src/Frontend-STFL/STFL/StflApi.cs
+++ b/src/Frontend-STFL/STFL/StflApi.cs
@@ -103,7 +103,7 @@ namespace Stfl
         {
             // calculate length
             int length = 0;
-            while (Marshal.ReadInt32(ptr, length) != 0) {
+            while (Marshal.ReadInt32(ptr, 4 * length) != 0) {
                 ++length;
             }
 


### PR DESCRIPTION
When finding the string length, advance by four bytes instead of one.

Sorry for opening a buggy pull request in the first place... now it works.