### PR TITLE
Frontend-STFL: Implement /window list.

### DIFF
--- a/src/Frontend-STFL/Entry.cs
+++ b/src/Frontend-STFL/Entry.cs
@@ -256,7 +256,7 @@ namespace Smuxi.Frontend.Stfl
             chatView.AddMessage(builder.ToMessage());
 
             string[] help = {
-                "window (number|close)",
+                "window (number|list|close)",
                 "exit",
             };
 
@@ -272,6 +272,21 @@ namespace Smuxi.Frontend.Stfl
         {
             if (cmd.Parameter == "close") {
                 f_ChatViewManager.CurrentChat.Close();
+                return;
+            } else if (cmd.Parameter == "list") {
+                var thisChatView = f_MainWindow.ChatViewManager.GetChat(cmd.Chat);
+
+                for (int i = 0;; ++i) {
+                    ChatView availableChatView = f_MainWindow.ChatViewManager.GetChat(i);
+                    if (availableChatView == null) {
+                        break;
+                    }
+
+                    var builder = new MessageBuilder();
+                    builder.AppendEventPrefix();
+                    builder.AppendFormat("{0} - {1}", i + 1, availableChatView.Name ?? "");
+                    thisChatView.AddMessage(builder.ToMessage());
+                }
                 return;
             }
 


### PR DESCRIPTION
On small terminals, e.g. SSH clients on mobile phones, the screen may not
be wide enough to display more than a few tabs. /window list outputs a list
of all windows and their numbers (for selection via /window number) into
the current chat window.