### PR TITLE
Campfire: better support for tweets

### DIFF
--- a/src/Engine-Campfire/Protocols/Campfire/CampfireProtocolManager.cs
+++ b/src/Engine-Campfire/Protocols/Campfire/CampfireProtocolManager.cs
@@ -357,7 +357,7 @@ namespace Smuxi.Engine
 
         void SendMessage(GroupChatModel chat, string text)
         {
-            var message = new MessageSending { body = text, type = Campfire.MessageType.TextMessage};
+            var message = new MessageSending { body = text };
             var wrapper = new MessageWrapper { message = message };
             Message res;
             try {

--- a/src/Engine-Campfire/Protocols/Campfire/CampfireProtocolManager.cs
+++ b/src/Engine-Campfire/Protocols/Campfire/CampfireProtocolManager.cs
@@ -390,6 +390,11 @@ namespace Smuxi.Engine
             bld.AppendText(action);
         }
 
+        bool AlreadyPosted(PersonModel person, int messageId)
+        {
+            return person == Me && messageId <= LastSentId;
+        }
+
         void ShowMessage(object sender, MessageReceivedEventArgs args)
         {
             var message = args.Message;
@@ -443,6 +448,15 @@ namespace Smuxi.Engine
                 case Campfire.MessageType.UploadMessage:
                     FormatUpload(bld, person, chat, message);
                     break;
+                case Campfire.MessageType.TweetMessage:
+                    if (AlreadyPosted(person, message.Id))
+                        return;
+
+                    var tweet = message.Tweet;
+                    // TRANSLATOR: {0} is the twitter username, {1} the tweet text
+                    FormatEvent(bld, person,
+                        String.Format(_("has pasted a tweet by {0}: {1}"), tweet.Author_Username, tweet.Message));
+                    break;
                 case Campfire.MessageType.TextMessage:
                 case Campfire.MessageType.PasteMessage:
                     processed = false;
@@ -457,19 +471,17 @@ namespace Smuxi.Engine
                 return;
             }
 
-            bool mine = person == Me;
-
-            // Don't double-post the messages we've sent
-            if (mine && message.Id <= LastSentId)
+            if (AlreadyPosted(person, message.Id))
                 return;
+
+            bool mine = person == Me;
 
             if (mine)
                 bld.AppendSenderPrefix(Me);
             else
                 bld.AppendNick(person).AppendSpace();
 
-            if (message.Type == Campfire.MessageType.TextMessage ||
-                message.Type == Campfire.MessageType.TweetMessage) {
+            if (message.Type == Campfire.MessageType.TextMessage) {
                 bld.AppendMessage(message.Body);
             } else if (message.Type == Campfire.MessageType.PasteMessage) {
                 bld.AppendText("\n");

--- a/src/Engine-Campfire/Protocols/Campfire/DTO.cs
+++ b/src/Engine-Campfire/Protocols/Campfire/DTO.cs
@@ -75,6 +75,13 @@ namespace Smuxi.Engine.Campfire
         public string body { get; set; }
     }
 
+    internal class Tweet {
+        public long Id { get; set; }
+        public string Message { get; set; }
+        public string Author_Username { get; set; }
+        public string Author_Avatar_Url { get; set; }
+    }
+
     internal class Message {
         public int Id { get; set; }
         public string Body { get; set; }
@@ -83,6 +90,7 @@ namespace Smuxi.Engine.Campfire
         public DateTimeOffset Created_At { get; set; }
         public MessageType Type { get; set; }
         public bool Starred { get; set; }
+        public Tweet Tweet { get; set; }
     }
 
     internal class Upload {

--- a/src/Engine-Campfire/Protocols/Campfire/DTO.cs
+++ b/src/Engine-Campfire/Protocols/Campfire/DTO.cs
@@ -71,7 +71,6 @@ namespace Smuxi.Engine.Campfire
     }
 
     internal class MessageSending {
-        public MessageType type { get; set; }
         public string body { get; set; }
     }
 


### PR DESCRIPTION
The server tells us about the tweets which people paste, so we can use that information to show it, instead of 'unkown action' like we do now.

On the sending side, let the server decide whether we pasted a twitter link or a multi-line paste or whatever. This lets us generate these tweet messages in the channel instead of just pasting the link, and the same goes for multi-line.