### PR TITLE
build: ignore case in `git-contributors` script

### DIFF
--- a/build/git-contributors
+++ b/build/git-contributors
@@ -3,5 +3,5 @@ git log --no-merges "$@" | \
 	grep ^Author: | \
 	sed 's/ <.*//; s/^Author: //' | \
 	sort | \
-	uniq -c | \
+	uniq -ic | \
 	sort -nr

--- a/build/git-contributors
+++ b/build/git-contributors
@@ -1,2 +1,7 @@
 #!/bin/sh
-git log --no-merges "$@" | grep ^Author: | sed 's/ <.*//; s/^Author: //' | sort | uniq -c | sort -nr
+git log --no-merges "$@" | \
+	grep ^Author: | \
+	sed 's/ <.*//; s/^Author: //' | \
+	sort | \
+	uniq -c | \
+	sort -nr


### PR DESCRIPTION
Without this, some contributors would be duplicated, such as:

 9 Clement BOURGEOIS
 9 Clement Bourgeois

After:

 18 Clement Bourgeois