### PR TITLE
README: add command for daily ppa

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ debian/
 -------
 
 The debian/ directory contains upstream packaging used for the daily development
-builds for Ubuntu and Debian found on [launchpad][].
+builds for Ubuntu and Debian found on [launchpad][] (which you can subscribe to
+via `sudo add-apt-repository -y ppa:meebey/smuxi-daily && sudo apt update`).
 The official (downstream) Debian packaging can be found on [here][].
 
   [launchpad]: https://launchpad.net/~meebey/+archive/smuxi-daily


### PR DESCRIPTION
The launchpad pages for PPAs are the opposite of intuitive when
you just want to know the command to use to subscribe to them,
so as a tiny workaround for smuxi we can add the command here
to prevent extra clicks and headaches.