### PR TITLE
autogen.sh: prefer shallow git submodules if parent is shallow

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -61,7 +61,7 @@ DIE=0
 if test "$DIE" -eq 1; then
         exit 1
 fi
-                                                                                
+
 #test $TEST_TYPE $FILE || {
 #        echo "You must run this script in the top-level $PROJECT directory"
 #        exit 1
@@ -101,7 +101,17 @@ echo "Running $AUTOCONF ..."
 $AUTOCONF
 
 if test x$NOGIT = x; then
-    git submodule update --init --recursive || exit 1
+
+    # if parent is shallow, assume user also wants shallow submodules
+    if [ -f .git/shallow ]; then
+
+        # use depth=1 as it's not easy to determine the depth of parent, see
+        # http://stackoverflow.com/questions/37182919/how-to-know-the-depth-of-a-gits-shallow-clone
+        git submodule update --init --recursive --depth=1 || exit 1
+
+    else
+        git submodule update --init --recursive || exit 1
+    fi
 else
     echo Skipping git submodule initialization.
 fi


### PR DESCRIPTION
The most likely scenario for someone to use a shallow
clone is to save some bandwidth (especially useful for
slow or data-capped connections), so it makes sense to
assume that the submodules should be retreived in a
similar way (especially considering some submodules
that Smuxi depends on are quite heavy, possibly due to
inclusion of binaries).