### PR TITLE
Engine: ID in MessageDTO, for SQLite (de)serialization

### DIFF
--- a/src/Engine/Engine.csproj
+++ b/src/Engine/Engine.csproj
@@ -114,6 +114,7 @@
     <Compile Include="MessageBuffers\JsonMessageBuffer.cs" />
     <Compile Include="Messages\Dto\MessageDtoModelV1.cs" />
     <Compile Include="MessageBuffers\SqliteMessageBuffer.cs" />
+    <Compile Include="Messages\Dto\MessageDtoModelV2.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Protocols\" />

--- a/src/Engine/Makefile.am
+++ b/src/Engine/Makefile.am
@@ -43,7 +43,7 @@ PROGRAMFILES = \
 
 LINUX_PKGCONFIG = \
 	$(ENGINE_PC)  
-	
+
 all: $(ASSEMBLY) $(PROGRAMFILES) $(LINUX_PKGCONFIG) 
 
 FILES = \
@@ -77,6 +77,7 @@ FILES = \
 	Messages/ImageMessagePartModel.cs \
 	Messages/MessageType.cs \
 	Messages/Dto/MessageDtoModelV1.cs \
+	Messages/Dto/MessageDtoModelV2.cs \
 	Chats/ChatType.cs \
 	Chats/ChatModel.cs \
 	Chats/GroupChatModel.cs \

--- a/src/Engine/MessageBuffers/SqliteMessageBuffer.cs
+++ b/src/Engine/MessageBuffers/SqliteMessageBuffer.cs
@@ -204,7 +204,7 @@ namespace Smuxi.Engine
                 RemoveAt(0);
             }
 
-            var dto = new MessageDtoModelV1(msg);
+            var dto = new MessageDtoModelV2(msg);
             var json = JsonSerializer.SerializeToString(dto);
 
             using (var cmd = Connection.CreateCommand()) {
@@ -241,7 +241,7 @@ namespace Smuxi.Engine
                     var msgs = new List<MessageModel>(limit);
                     while (reader.Read()) {
                         var json = (string) reader["JSON"];
-                        var dto = JsonSerializer.DeserializeFromString<MessageDtoModelV1>(json);
+                        var dto = JsonSerializer.DeserializeFromString<MessageDtoModelV2>(json);
                         var msg = dto.ToMessage();
                         msgs.Add(msg);
                     }

--- a/src/Engine/Messages/Dto/MessageDtoModelV1.cs
+++ b/src/Engine/Messages/Dto/MessageDtoModelV1.cs
@@ -48,7 +48,7 @@ namespace Smuxi.Engine.Dto
             }
         }
 
-        public MessageModel ToMessage()
+        public virtual MessageModel ToMessage()
         {
             var msg = new MessageModel() {
                 MessageType = this.MessageType,

--- a/src/Engine/Messages/Dto/MessageDtoModelV2.cs
+++ b/src/Engine/Messages/Dto/MessageDtoModelV2.cs
@@ -1,0 +1,43 @@
+﻿// Smuxi - Smart MUltipleXed Irc
+//
+// Copyright (c) 2016 Andres G. Aragoneses
+//
+// Full GPL License: <http://www.gnu.org/licenses/gpl.txt>
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307 USA
+using System;
+using System.Collections.Generic;
+
+namespace Smuxi.Engine.Dto
+{
+    public class MessageDtoModelV2 : MessageDtoModelV1
+    {
+        public string ID { get; set; }
+
+        public MessageDtoModelV2(MessageModel msg) :
+                            base(msg)
+        {
+            ID = msg.ID;
+        }
+
+        public override MessageModel ToMessage()
+        {
+            var msg = base.ToMessage();
+            msg.ID = ID;
+            return msg;
+        }
+    }
+}
+


### PR DESCRIPTION
Ability for messages to hold an ID started with a Twitter
feature in [0]. But it was missing serialization, which
was added in [1].

However, SQLiteMessageBuffer serialization was also missing,
something which is fixed in this commit

The consequence of this new property not being present in
MessageBuffer serialization was that the new timeline links
implemented in [0] were only visible in the friends timeline
but not in new timelines spawned by the /timeline command.

[0] https://github.com/meebey/smuxi/commit/e2b6670c7d7e5580aa872944a838e92090f564a5
[1] https://github.com/meebey/smuxi/commit/b19662693f28a14a9f9bc7a74f6d288906eb005a