### PR TITLE
Engine(-IRC): prevent highlights from self (closes: #1095)

### DIFF
--- a/src/Engine-IRC/Protocols/Irc/IrcProtocolManager.cs
+++ b/src/Engine-IRC/Protocols/Irc/IrcProtocolManager.cs
@@ -3026,9 +3026,9 @@ namespace Smuxi.Engine
             UpdateGroupPerson(chat, e.Data);
 
             var builder = CreateMessageBuilder();
-            builder.AppendMessage(GetPerson(chat, e.Data.Nick ?? e.Data.From),
-                                  e.Data.Message);
-            builder.MarkHighlights();
+            PersonModel senderPerson = GetPerson(chat, e.Data.Nick ?? e.Data.From);
+            builder.AppendMessage(senderPerson, e.Data.Message);
+            builder.MarkHighlights(senderPerson);
 
             var msg = builder.ToMessage();
             Session.AddMessageToChat(chat, msg);
@@ -3038,7 +3038,7 @@ namespace Smuxi.Engine
                                      e.Data.Channel)
             );
         }
-        
+
         private void _OnChannelAction(object sender, ActionEventArgs e)
         {
             var chat = GetChat(e.Data.Channel, ChatType.Group) ?? Chat;
@@ -3046,10 +3046,11 @@ namespace Smuxi.Engine
 
             var builder = CreateMessageBuilder();
             builder.AppendActionPrefix();
-            builder.AppendIdendityName(GetPerson(chat, e.Data.Nick ?? e.Data.From));
+            PersonModel senderPerson = GetPerson(chat, e.Data.Nick ?? e.Data.From);
+            builder.AppendIdendityName(senderPerson);
             builder.AppendText(" ");
             builder.AppendMessage(e.ActionMessage);
-            builder.MarkHighlights();
+            builder.MarkHighlights(senderPerson);
 
             var msg = builder.ToMessage();
             Session.AddMessageToChat(chat, msg);

--- a/src/Engine/Messages/MessageBuilder.cs
+++ b/src/Engine/Messages/MessageBuilder.cs
@@ -487,6 +487,13 @@ namespace Smuxi.Engine
             MarkAsHighlight();
         }
 
+        public virtual void MarkHighlights(PersonModel sender)
+        {
+            if (sender != Me) {
+                MarkHighlights();
+            }
+        }
+
         public virtual void MarkAsHighlight()
         {
             // colorize the whole message


### PR DESCRIPTION
In theory, IRC is designed in a way in which all messages from
your current handle are always sent from your own client.

However, with the advent of IRC bridges, such as the Slack one,
it's feasible to use your IRC handle from 2 places: smuxi and
the web (slack UI). In this case, when you sent a message using
the latter, you would get a smuxi highlight on the former
because the engine receives a message that contains your nick,
which is essentially a false positive.

This can be workarounded by adding a comparison to Me's property
in MessageBuilder class just before highlighting.