### PR TITLE
build: ignore accented chars in `git-contributors` script

### DIFF
--- a/build/git-contributors
+++ b/build/git-contributors
@@ -2,6 +2,7 @@
 git log --no-merges "$@" | \
 	grep ^Author: | \
 	sed 's/ <.*//; s/^Author: //' | \
+	iconv -f utf8 -t ascii//TRANSLIT | \
 	sort | \
 	uniq -ic | \
 	sort -nr


### PR DESCRIPTION
Without this, some contributors would be duplicated, such as:

 27 Clément Bourgeois
 16 Clement Bourgeois

After:

 43 Clement Bourgeois

Idea borrowed from:
http://stackoverflow.com/a/10207623/544947