### PR TITLE
Engine-Tests: mark failing NIE tests as Ignored("N/A")

### DIFF
--- a/src/Engine-Tests/JsonMessageBufferTests.cs
+++ b/src/Engine-Tests/JsonMessageBufferTests.cs
@@ -65,5 +65,42 @@ namespace Smuxi.Engine
             var buffer = (JsonMessageBuffer) Buffer;
             buffer.GetChunkFileName(Int64.MaxValue);
         }
+
+        const string DOES_NOT_APPLY = "N/A";
+
+        [Test]
+        [Ignore(DOES_NOT_APPLY)]
+        public override void Contains()
+        {
+            base.Contains();
+        }
+
+        [Test]
+        [Ignore(DOES_NOT_APPLY)]
+        public override void IndexOf()
+        {
+            base.IndexOf();
+        }
+
+        [Test]
+        [Ignore(DOES_NOT_APPLY)]
+        public override void Enumerator()
+        {
+            base.Enumerator();
+        }
+
+        [Test]
+        [Ignore(DOES_NOT_APPLY)]
+        public override void RemoveAt()
+        {
+            base.RemoveAt();
+        }
+
+        [Test]
+        [Ignore(DOES_NOT_APPLY)]
+        public override void Clear()
+        {
+            base.Clear();
+        }
     }
 }

--- a/src/Engine-Tests/MessageBufferTestsBase.cs
+++ b/src/Engine-Tests/MessageBufferTestsBase.cs
@@ -156,7 +156,7 @@ namespace Smuxi.Engine
         }
 
         [Test]
-        public void IndexOf()
+        public virtual void IndexOf()
         {
             Assert.AreEqual(1, Buffer.IndexOf(TestMessages[1]));
 
@@ -167,7 +167,7 @@ namespace Smuxi.Engine
         }
 
         [Test]
-        public void Contains()
+        public virtual void Contains()
         {
             Assert.IsTrue(Buffer.Contains(TestMessages[0]));
 
@@ -367,14 +367,14 @@ namespace Smuxi.Engine
         }
 
         [Test]
-        public void Clear()
+        public virtual void Clear()
         {
             Buffer.Clear();
             Assert.AreEqual(0, Buffer.Count);
         }
 
         [Test]
-        public void RemoveAt()
+        public virtual void RemoveAt()
         {
             Buffer.RemoveAt(0);
             Assert.AreEqual(TestMessages[1], Buffer[0]);
@@ -385,7 +385,7 @@ namespace Smuxi.Engine
         }
 
         [Test]
-        public void Enumerator()
+        public virtual void Enumerator()
         {
             int i = 0;
             foreach (var msg in Buffer) {

--- a/src/Engine-Tests/SqliteMessageBufferTests.cs
+++ b/src/Engine-Tests/SqliteMessageBufferTests.cs
@@ -75,5 +75,21 @@ namespace Smuxi.Engine
             Assert.AreEqual(Buffer.MaxCapacity, Buffer.Count);
             Assert.AreEqual(msgs[32 - (Buffer.MaxCapacity - bufferCount)].ToString(), Buffer[0].ToString());
         }
+
+        const string DOES_NOT_APPLY = "N/A";
+
+        [Test]
+        [Ignore(DOES_NOT_APPLY)]
+        public override void Contains()
+        {
+            base.Contains();
+        }
+
+        [Test]
+        [Ignore(DOES_NOT_APPLY)]
+        public override void IndexOf()
+        {
+            base.IndexOf();
+        }
     }
 }


### PR DESCRIPTION
Instead of having the build failing because the
tests throw NotImplementedException, we mark them
as Ignored for the subclasses where they don't
apply. The methods were not implemented because
the interface used for the MessageBuffer chosen
some time ago was IList, but it's too feature-rich
for these backends which, if implemented for them,
would be very expensive operations.