### PR TITLE
[WIP] Engine(-Tests): Unbreak heuristic for URLs without protocol

### DIFF
--- a/src/Engine-Tests/MessageBuilderTests.cs
+++ b/src/Engine-Tests/MessageBuilderTests.cs
@@ -593,12 +593,6 @@ namespace Smuxi.Engine
         [Test]
         public void AppendMessageWithNonUrls()
         {
-        }
-
-        [Test]
-        [Ignore]
-        public void BrokenAppendMessageWithNonUrls()
-        {
             var msg = "org.gnome.Foo.desktop";
             var builder = new MessageBuilder();
             builder.TimeStamp = DateTime.MinValue;

--- a/src/Engine/Config/MessageBuilderSettings.cs
+++ b/src/Engine/Config/MessageBuilderSettings.cs
@@ -122,8 +122,9 @@ namespace Smuxi.Engine
             // addresses without protocol (heuristical)
             // include well known TLDs to prevent autogen.sh, configure.ac or
             // Gst.Buffer.Unref() from matching
+            string endingSpaceOrInterrogation = "[\\s\\?]";
             string heuristic_domain = @"(?:(?:" + subdomain + ")+(?:" + common_tld + ")|localhost)";
-            string heuristic_address = heuristic_domain + "(?:" + path + ")?";
+            string heuristic_address = heuristic_domain + "(?:" + path + ")?" + endingSpaceOrInterrogation;
             regex = new Regex(
                 heuristic_address,
                 RegexOptions.IgnoreCase | RegexOptions.Compiled


### PR DESCRIPTION
[WIP] DO NOT MERGE, this is just a Proof Of Concept for now [/WIP]

This heuristic should have never considered strings as URLs
if there was not a delimiter character at the end (such as
a space or a question mark or the end of the string).