### PR TITLE
Engine(-Tests): Unbreak heuristic for URLs without protocol (v2)

### DIFF
--- a/src/Engine-Tests/MessageBuilderTests.cs
+++ b/src/Engine-Tests/MessageBuilderTests.cs
@@ -612,12 +612,6 @@ namespace Smuxi.Engine
         [Test]
         public void AppendMessageWithNonUrls()
         {
-        }
-
-        [Test]
-        [Ignore]
-        public void BrokenAppendMessageWithNonUrls()
-        {
             var msg = "org.gnome.Foo.desktop";
             var builder = new MessageBuilder();
             builder.TimeStamp = DateTime.MinValue;

--- a/src/Engine/Config/MessageBuilderSettings.cs
+++ b/src/Engine/Config/MessageBuilderSettings.cs
@@ -68,6 +68,8 @@ namespace Smuxi.Engine
             HighlightWords = settings.HighlightWords;
         }
 
+        internal const string EndDelimiterGroupName = "DelimiterForEndOfPattern";
+
         static void InitBuiltinSmartLinks()
         {
             string path_last_chars = @"a-zA-Z0-9#/%&@=\-_+;:~'";
@@ -123,7 +125,8 @@ namespace Smuxi.Engine
             // include well known TLDs to prevent autogen.sh, configure.ac or
             // Gst.Buffer.Unref() from matching
             string heuristic_domain = @"(?:(?:" + subdomain + ")+(?:" + common_tld + ")|localhost)";
-            string heuristic_address = heuristic_domain + "(?:" + path + ")?";
+            string end_delimiter = String.Format(@"(?<{0}>$|\s|\W)", EndDelimiterGroupName);
+            string heuristic_address = heuristic_domain + "(?:" + path + ")?" + end_delimiter;
             regex = new Regex(
                 heuristic_address,
                 RegexOptions.IgnoreCase | RegexOptions.Compiled

--- a/src/Engine/Messages/MessageBuilder.cs
+++ b/src/Engine/Messages/MessageBuilder.cs
@@ -892,12 +892,9 @@ namespace Smuxi.Engine
             
             int lastindex = 0;
             do {
-                var groupValues = new string[match.Groups.Count];
-                int i = 0;
-                foreach (Group @group in match.Groups) {
-                    groupValues[i++] = @group.Value;
-                }
-                
+                var groupValues = match.Groups.Cast<Group>()
+                    .Select(g => g.Value).ToArray();
+
                 string url;
                 if (String.IsNullOrEmpty(pattern.LinkFormat)) {
                     url = match.Value;

--- a/src/Engine/Messages/MessageBuilder.cs
+++ b/src/Engine/Messages/MessageBuilder.cs
@@ -892,7 +892,18 @@ namespace Smuxi.Engine
             
             int lastindex = 0;
             do {
+                var delimiterLength = 0;
+                var regexDelimiterForEndOfPatternValue = match.Groups[MessageBuilderSettings.EndDelimiterGroupName];
+                if (regexDelimiterForEndOfPatternValue != null) {
+                    delimiterLength = regexDelimiterForEndOfPatternValue.Value.Length;
+                }
+
                 var groupValues = match.Groups.Cast<Group>()
+
+                    // don't get the delimiter because it only determines
+                    // the end of pattern, which is not part of the pattern
+                    .Where(g => g != regexDelimiterForEndOfPatternValue)
+
                     .Select(g => g.Value).ToArray();
 
                 string url;
@@ -901,12 +912,14 @@ namespace Smuxi.Engine
                 } else {
                     url = String.Format(pattern.LinkFormat, groupValues);
                 }
+                url = url.Substring(0, url.Length - delimiterLength);
                 string text;
                 if (String.IsNullOrEmpty(pattern.TextFormat)) {
                     text = match.Value;
                 } else {
                     text = String.Format(pattern.TextFormat, groupValues);
                 }
+                text = text.Substring(0, text.Length - delimiterLength);
 
                 if (lastindex != match.Index) {
                     // there were some non-matching-chars before the match
@@ -932,7 +945,7 @@ namespace Smuxi.Engine
                     msgPart = new TextMessagePartModel(text);
                 }
                 msgParts.Add(msgPart);
-                lastindex = match.Index + match.Length;
+                lastindex = match.Index + match.Length - delimiterLength;
                 match = match.NextMatch();
             } while (match.Success);
             


### PR DESCRIPTION
This heuristic should have never considered strings as URLs
if there was not a delimiter character at the end (such as
a space or a question mark or the end of the string).

The testcase that this commit fixes was marked as [Ignore]d,
now it's not disabled anymore.
