### PR TITLE
Find the mono framework and copy bundled on macOS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -303,6 +303,8 @@ dist-linux-debs:
 run: run-gnome
 run-gnome: all
 	if [ "x$(shell uname)" = "xDarwin" ]; then \
+	  cp $(LIB_DIR)/log4net.dll $(BUILD_DIR); \
+	  cp $(LIB_DIR)/Nini.dll $(BUILD_DIR); \
 	  export DYLD_FALLBACK_LIBRARY_PATH=@WITH_MONO_FRAMEWORK@/lib:/lib:/usr/lib; \
 	fi; \
 	cd $(BUILD_DIR) && \

--- a/Makefile.am
+++ b/Makefile.am
@@ -303,7 +303,7 @@ dist-linux-debs:
 run: run-gnome
 run-gnome: all
 	if [ "x$(shell uname)" = "xDarwin" ]; then \
-	  export DYLD_FALLBACK_LIBRARY_PATH=/Library/Frameworks/Mono.framework/Versions/Current/lib:/lib:/usr/lib; \
+	  export DYLD_FALLBACK_LIBRARY_PATH=@WITH_MONO_FRAMEWORK@/lib:/lib:/usr/lib; \
 	fi; \
 	cd $(BUILD_DIR) && \
 		mono --debug ./smuxi-frontend-gnome.exe -d

--- a/configure.ac
+++ b/configure.ac
@@ -247,22 +247,24 @@ if test "$CLI_RUNTIME" = "4.5"; then
 fi
 AC_SUBST(XBUILD_FLAGS)
 
-# Required Libraries	
-PKG_CHECK_MODULES([LOG4NET], [log4net])
+# Required Libraries, which we bundle for macOS
+if "x$(uname)" = "xDarwin"; then
+	PKG_CHECK_MODULES([LOG4NET], [log4net])
 
-PKG_CHECK_EXISTS([nini-1.1], FOUND_NINI=yes, FOUND_NINI=no)
-nini_files=
-if test "x$FOUND_NINI" = "xyes"; then
-	nini_files=`pkg-config --variable=Libraries nini-1.1`
-	if test -z "$nini_files" ; then
-		# Debian-based distros place Nini into the GAC
-		PKG_CHECK_MODULES([NINI], [nini-1.1])
+	PKG_CHECK_EXISTS([nini-1.1], FOUND_NINI=yes, FOUND_NINI=no)
+	nini_files=
+	if test "x$FOUND_NINI" = "xyes"; then
+		nini_files=`pkg-config --variable=Libraries nini-1.1`
+		if test -z "$nini_files" ; then
+			# Debian-based distros place Nini into the GAC
+			PKG_CHECK_MODULES([NINI], [nini-1.1])
+		else
+			# openSUSE has Nini as a private assembly; need to copy it.
+			AC_SUBST([NINI_LIBS], "$nini_files")
+		fi
 	else
-		# openSUSE has Nini as a private assembly; need to copy it.
-		AC_SUBST([NINI_LIBS], "$nini_files")
+		PKG_CHECK_MODULES([NINI], [nini >= 1.1])
 	fi
-else
-	PKG_CHECK_MODULES([NINI], [nini >= 1.1])
 fi
 AM_CONDITIONAL([BUNDLE_NINI], test -n "$nini_files")
 

--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,19 @@ AC_SUBST([git_commit_hash], "$GIT_COMMIT_HASH")
 AC_SUBST([DEV_VERSION_SUFFIX])
 AC_SUBST([dist_version], "$DIST_VERSION")
 
+AC_ARG_WITH([mono-framework],
+  AC_HELP_STRING([--with-mono-framework="MONO_FRAMEWORK"],
+  [Set where to look for the mono framework (macOS) [default=/Library/Frameworks/Mono.framework/Versions/Current]]),
+  with_mono_framework=$enableval,
+  with_mono_framework=/Library/Frameworks/Mono.framework/Versions/Current
+)
+
+AS_IF([test  "xDarwin" = "x$(uname)" -a "x$with_mono_framework" != "xno"], [
+  export PKG_CONFIG_PATH=${with_mono_framework}/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}
+  AC_SUBST([WITH_MONO_FRAMEWORK], "$with_mono_framework")],
+  []
+)
+
 SHAMROCK_EXPAND_LIBDIR
 SHAMROCK_CHECK_MONO_MODULE(2.8)
 SHAMROCK_FIND_MONO_RUNTIME


### PR DESCRIPTION
The first commit gives us `--with-mono-framework` for macOS which automatically looks up the mono framework, letting us run `./autogen.sh` or `./configure` and not have it complain about the lack of mono.

The second change lets us do `make run` on macOS since log4net and nini aren't installed in the system GAC.

And since we're now copying them both for the zipfile and `make run`, let's stop asking the user to have log4net and nini installed on macOS as we're not using them anyway.