### PR TITLE
build: add push-transifex Makefile target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,8 +85,11 @@ update-pot:
 		$(MAKE) -C $$PODIR check 2>&1 | grep -v 'mismatched quotes at line' 2>&1; \
 	done
 
-update-transifex:
+pull-transifex:
 	tx pull -f -l ca,cs,da,de,en_GB,es,fa,fi,fr,hr,ko,lt,nb_NO,pl,pt_BR,ru,sk,sv,te,tr,ur,zh_CN
+
+push-transifex:
+	tx push -t --skip
 
 mail-po: update-po
 	for PODIR in $(PODIRS); do \


### PR DESCRIPTION
Also rename the previously committed `update-transifex`
to `pull-transifex` to distinguish better and sync with
the tx commands.

I just tested with Mirco that pushing an incomplete
translation to Transifex to a completed translation in
the server does not overwrite the work but it merges
it on the server, so it's fine if no -l parameter is
used here (meaning it defaults to pushing all langs).

--skip is needed because some translations may be
unfinished containing translation files that don't
have any translated strings, and the tx push command
would fail on those with the error "Could not import
file: We're not able to extract any string from the
file uploaded for language Persian (fa) in resource
Smuxi - IRC client: smuxi-server.pot"