### PR TITLE
travis: install libnunit-cil-dev manually to fix build with new Mono

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
     - sudo apt-get install devscripts equivs > /dev/null
     - sudo mk-build-deps --install debian/control > /dev/null
     - sudo apt-get install mono-devel nunit-console moreutils gtk-sharp2-gapi libgtkspell-dev > /dev/null
+    - sudo apt-get install libnunit-cil-dev > /dev/null
 
 script:
     - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
     - sudo apt-get install mono-devel nunit-console moreutils gtk-sharp2-gapi libgtkspell-dev > /dev/null
 
 script:
+    - set -e
     - ./autogen.sh
     - find lib/ -name "*.csproj" -exec sed 's!<WarningLevel>[0-9]</WarningLevel>!<WarningLevel>0</WarningLevel>!' -i {} \;
     - sed 's!<Package>dbus-sharp-2.0</Package>!<Package>dbus-sharp-1.0</Package>!' -i src/Frontend-GNOME/Frontend-GNOME.csproj

--- a/configure.ac
+++ b/configure.ac
@@ -247,6 +247,7 @@ AC_SUBST(XBUILD_FLAGS)
 
 # Required Libraries	
 PKG_CHECK_MODULES([LOG4NET], [log4net])
+PKG_CHECK_MODULES([NUNIT], [nunit])
 
 PKG_CHECK_EXISTS([nini-1.1], FOUND_NINI=yes, FOUND_NINI=no)
 nini_files=


### PR DESCRIPTION
Newer versions of Mono such as 6.6.x don't provide NUnit anymore so the
package needs to be installed separately, otherwise the build fails like
it was happening for the master branch in its latest commit:

https://github.com/meebey/smuxi/commit/d4cfb71d70cadd8a9fd218e2089f1e32ad149c63

Whose build log was:

https://travis-ci.org/meebey/smuxi/builds/627714687?utm_source=github_status&utm_medium=notification