### PR TITLE
debian: remove unneeded libtool dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,6 @@ Build-Depends-Indep: cli-common-dev (>= 0.5.7),
  pkg-config,
  gettext,
  intltool,
- libtool-bin | libtool (<< 2.4.2-1.8~),
  autoconf,
  automake,
  autotools-dev


### PR DESCRIPTION
It was removed in 8755847015c8857cf6da63c061722f21dfd2b88c