### PR TITLE
Frontend-GNOME: remove --debug flag from launcher script

### DIFF
--- a/src/Frontend-GNOME/smuxi-frontend-gnome.in
+++ b/src/Frontend-GNOME/smuxi-frontend-gnome.in
@@ -32,4 +32,4 @@ chmod 700 $SMUXI_TMP
 TMP=$SMUXI_TMP
 export TMP
 
-exec mono --debug "@expanded_libdir@/@PACKAGE@/smuxi-frontend-gnome.exe" "$@"
+exec mono "@expanded_libdir@/@PACKAGE@/smuxi-frontend-gnome.exe" "$@"


### PR DESCRIPTION
This would be making Smuxi much slower than it needs to; since many optimizations may not be enabled when running in debug mode.

If a developer wants to still run in debug mode after this, she still has two options:

a) Use `make run` which still launches smuxi with the --debug flag.

b) Export env var `MONO_OPTIONS=--debug` before launching smuxi.